### PR TITLE
Phase 1: E2E tests skip real API calls by default

### DIFF
--- a/.iw/test/feedback.bats
+++ b/.iw/test/feedback.bats
@@ -59,8 +59,8 @@ teardown() {
 
 @test "feedback creates issue successfully" {
     # Skip if no real token available
-    if [ -z "$LINEAR_API_TOKEN" ]; then
-        skip "LINEAR_API_TOKEN not set, skipping live API test"
+    if [ -z "$LINEAR_API_TOKEN" ] || [ -z "$ENABLE_LIVE_API_TESTS" ]; then
+        skip "Live API tests disabled. Set LINEAR_API_TOKEN and ENABLE_LIVE_API_TESTS=1 to enable."
     fi
 
     # Create issue with [TEST] prefix for easy identification
@@ -75,8 +75,8 @@ teardown() {
 
 @test "feedback with description creates issue" {
     # Skip if no real token available
-    if [ -z "$LINEAR_API_TOKEN" ]; then
-        skip "LINEAR_API_TOKEN not set, skipping live API test"
+    if [ -z "$LINEAR_API_TOKEN" ] || [ -z "$ENABLE_LIVE_API_TESTS" ]; then
+        skip "Live API tests disabled. Set LINEAR_API_TOKEN and ENABLE_LIVE_API_TESTS=1 to enable."
     fi
 
     # Create issue with description
@@ -91,8 +91,8 @@ teardown() {
 
 @test "feedback with bug type creates issue" {
     # Skip if no real token available
-    if [ -z "$LINEAR_API_TOKEN" ]; then
-        skip "LINEAR_API_TOKEN not set, skipping live API test"
+    if [ -z "$LINEAR_API_TOKEN" ] || [ -z "$ENABLE_LIVE_API_TESTS" ]; then
+        skip "Live API tests disabled. Set LINEAR_API_TOKEN and ENABLE_LIVE_API_TESTS=1 to enable."
     fi
 
     # Create bug issue

--- a/project-management/issues/IWLE-131/implementation-log.md
+++ b/project-management/issues/IWLE-131/implementation-log.md
@@ -1,0 +1,41 @@
+# Implementation Log: E2E tests create real issues in Linear - need mock or sandbox
+
+**Issue:** IWLE-131
+
+This log tracks the evolution of implementation across phases.
+
+---
+
+## Phase 1: E2E tests skip real API calls by default (2025-12-21)
+
+**What was built:**
+- Modified `.iw/test/feedback.bats` to require `ENABLE_LIVE_API_TESTS` environment variable for live API tests
+
+**Changes made:**
+- Updated skip conditions in 3 test functions to check for both `LINEAR_API_TOKEN` AND `ENABLE_LIVE_API_TESTS`
+- Updated skip messages to clearly explain both requirements
+
+**Decisions made:**
+- Used simple OR condition (`-z "$VAR1" || -z "$VAR2"`) for clarity
+- Skip message explains how to enable: "Set LINEAR_API_TOKEN and ENABLE_LIVE_API_TESTS=1 to enable"
+
+**Testing:**
+- Verified all 8 feedback tests pass/skip correctly with no env vars set
+- Live API tests (3) now skip by default
+- Non-API tests (5) continue to pass unchanged
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-01-20251221-222014.md
+- Status: PASSED (no critical issues)
+
+**For next phases:**
+- Phase 2 can add warning messages when live tests are enabled
+- Phase 3 can add mock-based unit tests independently
+
+**Files changed:**
+```
+M .iw/test/feedback.bats
+```
+
+---

--- a/project-management/issues/IWLE-131/phase-01-tasks.md
+++ b/project-management/issues/IWLE-131/phase-01-tasks.md
@@ -1,0 +1,51 @@
+# Phase 1 Tasks: E2E tests skip real API calls by default
+
+**Issue:** IWLE-131
+**Phase:** 1 of 3
+**Status:** Complete
+
+## Implementation Tasks
+
+### [impl] Core Implementation
+
+- [x] [impl] Update skip condition in "feedback creates issue successfully" test to require ENABLE_LIVE_API_TESTS
+- [x] [impl] Update skip condition in "feedback with description creates issue" test to require ENABLE_LIVE_API_TESTS
+- [x] [impl] Update skip condition in "feedback with bug type creates issue" test to require ENABLE_LIVE_API_TESTS
+
+### [test] Verification
+
+- [x] [test] Verify all tests pass when no env vars set (unset LINEAR_API_TOKEN ENABLE_LIVE_API_TESTS)
+
+## Detailed Implementation
+
+### Task 1-3: Update Skip Conditions
+
+For each of the three live API tests, change:
+```bash
+if [ -z "$LINEAR_API_TOKEN" ]; then
+    skip "LINEAR_API_TOKEN not set, skipping live API test"
+fi
+```
+
+To:
+```bash
+if [ -z "$LINEAR_API_TOKEN" ] || [ -z "$ENABLE_LIVE_API_TESTS" ]; then
+    skip "Live API tests disabled. Set LINEAR_API_TOKEN and ENABLE_LIVE_API_TESTS=1 to enable."
+fi
+```
+
+### Task 4: Verification
+
+Run tests in clean environment to verify they pass/skip correctly:
+```bash
+unset LINEAR_API_TOKEN ENABLE_LIVE_API_TESTS
+./iw test e2e
+```
+
+Expected: All 8 tests run, 3 live API tests skip with new message.
+
+## Notes
+
+- This is a simple refactoring task - changing skip logic in 3 tests
+- No structural changes needed
+- Skip message should be informative and actionable

--- a/project-management/issues/IWLE-131/review-phase-01-20251221-222014.md
+++ b/project-management/issues/IWLE-131/review-phase-01-20251221-222014.md
@@ -1,0 +1,66 @@
+# Code Review: Phase 1 - E2E tests skip real API calls by default
+
+**Issue:** IWLE-131
+**Phase:** 1
+**Date:** 2025-12-21
+**Iteration:** 1/3
+**Status:** PASSED
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| Warnings | 0 |
+| Suggestions | 1 |
+
+## Files Reviewed
+
+- `.iw/test/feedback.bats` (3 test functions modified)
+
+## Changes Analysis
+
+### Modified Test Functions
+
+1. **"feedback creates issue successfully"** (lines 62-64)
+   - Added `ENABLE_LIVE_API_TESTS` check to skip condition
+   - Updated skip message to explain both requirements
+
+2. **"feedback with description creates issue"** (lines 78-80)
+   - Same change as above
+
+3. **"feedback with bug type creates issue"** (lines 94-96)
+   - Same change as above
+
+### Correctness
+
+✅ All changes implement the intended behavior correctly:
+- Tests skip when `LINEAR_API_TOKEN` is not set
+- Tests skip when `ENABLE_LIVE_API_TESTS` is not set
+- Tests only run when BOTH environment variables are set
+- Skip message clearly explains what's needed
+
+### Consistency
+
+✅ All three test functions use identical skip logic and message
+
+### Non-API Tests
+
+✅ Non-API tests (validation errors, help text) remain unchanged as intended
+
+## Suggestions
+
+1. **Minor: Comment accuracy** (lines 61, 77, 93)
+   - Comments say "Skip if no real token available"
+   - Could be updated to "Skip if live API tests disabled"
+   - Low priority - current comment is still technically accurate
+
+## Verification
+
+- E2E tests pass when no environment variables are set
+- Live API tests skip with correct message
+- Non-API tests continue to work
+
+## Conclusion
+
+**APPROVED** - Changes are minimal, correct, and implement the intended functionality.


### PR DESCRIPTION
## Phase 1: E2E tests skip real API calls by default

**Goals**: Make E2E tests safe to run repeatedly without creating real Linear issues. By default, tests that would create real issues should be skipped, requiring explicit opt-in via `ENABLE_LIVE_API_TESTS=1`.

**Changes**:
- Updated skip conditions in 3 feedback.bats test functions
- Tests now require both `LINEAR_API_TOKEN` AND `ENABLE_LIVE_API_TESTS`
- Skip message clearly explains: "Live API tests disabled. Set LINEAR_API_TOKEN and ENABLE_LIVE_API_TESTS=1 to enable."

**Testing**:
- All 8 feedback tests pass/skip correctly with no env vars
- Live API tests (3) skip by default
- Non-API tests (5) continue to pass unchanged

**Review**: See `project-management/issues/IWLE-131/review-phase-01-20251221-222014.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)