### PR TITLE
Phase 1: Display artifacts from state file

### DIFF
--- a/.iw/core/CachedReviewState.scala
+++ b/.iw/core/CachedReviewState.scala
@@ -1,0 +1,39 @@
+// PURPOSE: Cache wrapper for review state with mtime validation
+// PURPOSE: Tracks file modification timestamps to invalidate stale cached data
+
+package iw.core.domain
+
+/** Cached review state with file modification timestamps.
+  *
+  * @param state The review state data
+  * @param filesMtime Map of file path to modification time (epoch millis)
+  */
+case class CachedReviewState(
+  state: ReviewState,
+  filesMtime: Map[String, Long]
+)
+
+object CachedReviewState:
+  /** Check if cached review state is still valid based on file modification times.
+    *
+    * Cache is valid if:
+    * - All current files exist in cache with same mtime
+    * - No new files have been added
+    * - No files have been removed
+    *
+    * @param cached Cached review state with stored mtimes
+    * @param currentMtimes Current file modification times
+    * @return True if cache is still valid, false if needs re-parsing
+    */
+  def isValid(cached: CachedReviewState, currentMtimes: Map[String, Long]): Boolean =
+    // Check if sets of files are the same
+    val cachedFiles = cached.filesMtime.keySet
+    val currentFiles = currentMtimes.keySet
+
+    if cachedFiles != currentFiles then
+      false // File added or removed
+    else
+      // Check if all mtimes match
+      currentMtimes.forall { case (path, mtime) =>
+        cached.filesMtime.get(path).contains(mtime)
+      }

--- a/.iw/core/CaskServer.scala
+++ b/.iw/core/CaskServer.scala
@@ -32,12 +32,13 @@ class CaskServer(statePath: String, port: Int, hosts: Seq[String], startedAt: In
         val configPath = os.pwd / Constants.Paths.IwDir / Constants.Paths.ConfigFileName
         val config = ConfigFileRepository.read(configPath)
 
-        // Render dashboard with issue data, progress, and PR data
+        // Render dashboard with issue data, progress, PR data, and review state
         val html = DashboardService.renderDashboard(
           worktrees,
           state.issueCache,
           state.progressCache,
           state.prCache,
+          state.reviewStateCache,
           config
         )
 

--- a/.iw/core/ReviewState.scala
+++ b/.iw/core/ReviewState.scala
@@ -1,0 +1,31 @@
+// PURPOSE: Domain model for review state and artifacts
+// PURPOSE: Represents review state data from review-state.json files
+
+package iw.core.domain
+
+/** Artifact available for review.
+  *
+  * @param label Human-readable label for the artifact (e.g., "Analysis", "Phase Context")
+  * @param path Relative path to the artifact file from worktree root
+  */
+case class ReviewArtifact(
+  label: String,
+  path: String
+)
+
+/** Review state for a worktree issue.
+  *
+  * Represents the state of review artifacts, optionally including
+  * review status, phase number, and message.
+  *
+  * @param status Optional review status (e.g., "awaiting_review", "in_review")
+  * @param phase Optional phase number associated with review
+  * @param message Optional message about review state
+  * @param artifacts List of artifacts available for review (required field)
+  */
+case class ReviewState(
+  status: Option[String],
+  phase: Option[Int],
+  message: Option[String],
+  artifacts: List[ReviewArtifact]
+)

--- a/.iw/core/ReviewStateService.scala
+++ b/.iw/core/ReviewStateService.scala
@@ -1,0 +1,135 @@
+// PURPOSE: Application service for review state loading and parsing
+// PURPOSE: Pure business logic with file I/O injection pattern
+
+package iw.core.application
+
+import iw.core.domain.{ReviewState, ReviewArtifact, CachedReviewState}
+
+/** Application service for review state tracking.
+  *
+  * Uses file I/O injection pattern for testability.
+  * All logic is pure except for file operations injected from caller.
+  */
+object ReviewStateService:
+
+  /** Parse review state from JSON string.
+    *
+    * Expects JSON format:
+    * {
+    *   "status": "awaiting_review",  // optional
+    *   "phase": 8,                    // optional
+    *   "message": "Ready",            // optional
+    *   "artifacts": [                 // required
+    *     {"label": "Analysis", "path": "project-management/issues/46/analysis.md"}
+    *   ]
+    * }
+    *
+    * @param json JSON string to parse
+    * @return Either error message or ReviewState
+    */
+  def parseReviewStateJson(json: String): Either[String, ReviewState] =
+    try
+      import upickle.default.*
+
+      // Define JSON readers for domain models
+      given ReadWriter[ReviewArtifact] = macroRW[ReviewArtifact]
+
+      // Custom reader for ReviewState that handles optional fields
+      given ReadWriter[ReviewState] = readwriter[ujson.Value].bimap[ReviewState](
+        state => ujson.Obj(
+          "status" -> (state.status match {
+            case Some(s) => ujson.Str(s)
+            case None => ujson.Null
+          }),
+          "phase" -> (state.phase match {
+            case Some(p) => ujson.Num(p)
+            case None => ujson.Null
+          }),
+          "message" -> (state.message match {
+            case Some(m) => ujson.Str(m)
+            case None => ujson.Null
+          }),
+          "artifacts" -> writeJs(state.artifacts)
+        ),
+        jsValue => {
+          val obj = jsValue.obj
+
+          // artifacts is required
+          val artifacts = obj.get("artifacts") match {
+            case Some(arr) => read[List[ReviewArtifact]](arr)
+            case None => throw new Exception("Missing required field: artifacts")
+          }
+
+          // Optional fields
+          val status = obj.get("status").flatMap {
+            case ujson.Null => None
+            case ujson.Str(s) => Some(s)
+            case _ => None
+          }
+
+          val phase = obj.get("phase").flatMap {
+            case ujson.Null => None
+            case ujson.Num(n) => Some(n.toInt)
+            case _ => None
+          }
+
+          val message = obj.get("message").flatMap {
+            case ujson.Null => None
+            case ujson.Str(s) => Some(s)
+            case _ => None
+          }
+
+          ReviewState(status, phase, message, artifacts)
+        }
+      )
+
+      val parsed = read[ReviewState](json)
+      Right(parsed)
+    catch
+      case e: Exception => Left(s"Failed to parse review state JSON: ${e.getMessage}")
+
+  /** Fetch review state with cache support.
+    *
+    * Checks cache validity using file modification time.
+    * Re-parses JSON file if cache is invalid or missing.
+    *
+    * File I/O is injected for testability (FCIS pattern).
+    *
+    * @param issueId Issue identifier (e.g., "IWLE-123")
+    * @param worktreePath Path to worktree root
+    * @param cache Existing review state cache
+    * @param readFile Function to read file content (injected I/O)
+    * @param getMtime Function to get file modification time (injected I/O)
+    * @return Either error message or ReviewState
+    */
+  def fetchReviewState(
+    issueId: String,
+    worktreePath: String,
+    cache: Map[String, CachedReviewState],
+    readFile: String => Either[String, String],
+    getMtime: String => Either[String, Long]
+  ): Either[String, ReviewState] =
+    val reviewStatePath = s"$worktreePath/project-management/issues/$issueId/review-state.json"
+
+    // Get current mtime
+    getMtime(reviewStatePath) match {
+      case Left(err) =>
+        // File doesn't exist or can't read mtime
+        Left(err)
+
+      case Right(currentMtime) =>
+        val currentMtimes = Map(reviewStatePath -> currentMtime)
+
+        // Check cache validity
+        cache.get(issueId) match {
+          case Some(cached) if CachedReviewState.isValid(cached, currentMtimes) =>
+            // Cache is valid, return cached state
+            Right(cached.state)
+
+          case _ =>
+            // Cache invalid or missing, read and parse file
+            readFile(reviewStatePath).flatMap { content =>
+              parseReviewStateJson(content)
+            }
+        }
+    }

--- a/.iw/core/ServerState.scala
+++ b/.iw/core/ServerState.scala
@@ -7,7 +7,8 @@ case class ServerState(
   worktrees: Map[String, WorktreeRegistration],
   issueCache: Map[String, CachedIssue] = Map.empty,
   progressCache: Map[String, CachedProgress] = Map.empty,
-  prCache: Map[String, CachedPR] = Map.empty
+  prCache: Map[String, CachedPR] = Map.empty,
+  reviewStateCache: Map[String, CachedReviewState] = Map.empty
 ):
   def listByActivity: List[WorktreeRegistration] =
     worktrees.values.toList.sortBy(_.lastSeenAt.getEpochSecond)(Ordering[Long].reverse)
@@ -17,5 +18,6 @@ case class ServerState(
       worktrees = worktrees - issueId,
       issueCache = issueCache - issueId,
       progressCache = progressCache - issueId,
-      prCache = prCache - issueId
+      prCache = prCache - issueId,
+      reviewStateCache = reviewStateCache - issueId
     )

--- a/.iw/core/StateRepository.scala
+++ b/.iw/core/StateRepository.scala
@@ -3,7 +3,7 @@
 
 package iw.core.infrastructure
 
-import iw.core.domain.{ServerState, WorktreeRegistration, IssueData, CachedIssue, PhaseInfo, WorkflowProgress, CachedProgress, PullRequestData, PRState, CachedPR}
+import iw.core.domain.{ServerState, WorktreeRegistration, IssueData, CachedIssue, PhaseInfo, WorkflowProgress, CachedProgress, PullRequestData, PRState, CachedPR, ReviewState, ReviewArtifact, CachedReviewState}
 import java.nio.file.{Files, Paths, StandardCopyOption}
 import java.time.Instant
 import scala.util.{Try, Success, Failure}
@@ -38,13 +38,19 @@ case class StateRepository(statePath: String):
   given ReadWriter[PullRequestData] = macroRW[PullRequestData]
   given ReadWriter[CachedPR] = macroRW[CachedPR]
 
+  // Review state serialization
+  given ReadWriter[ReviewArtifact] = macroRW[ReviewArtifact]
+  given ReadWriter[ReviewState] = macroRW[ReviewState]
+  given ReadWriter[CachedReviewState] = macroRW[CachedReviewState]
+
   // JSON format matching the spec:
-  // { "worktrees": { "IWLE-123": { ... } }, "issueCache": { "IWLE-123": { ... } }, "progressCache": { "IWLE-123": { ... } }, "prCache": { "IWLE-123": { ... } } }
+  // { "worktrees": { "IWLE-123": { ... } }, "issueCache": { "IWLE-123": { ... } }, "progressCache": { "IWLE-123": { ... } }, "prCache": { "IWLE-123": { ... } }, "reviewStateCache": { "IWLE-123": { ... } } }
   case class StateJson(
     worktrees: Map[String, WorktreeRegistration],
     issueCache: Map[String, CachedIssue] = Map.empty,
     progressCache: Map[String, CachedProgress] = Map.empty,
-    prCache: Map[String, CachedPR] = Map.empty
+    prCache: Map[String, CachedPR] = Map.empty,
+    reviewStateCache: Map[String, CachedReviewState] = Map.empty
   )
   given ReadWriter[StateJson] = macroRW[StateJson]
 
@@ -54,12 +60,12 @@ case class StateRepository(statePath: String):
     if !Files.exists(path) then
       // Create empty state file if it doesn't exist
       ensureDirectoryExists()
-      Right(ServerState(Map.empty, Map.empty, Map.empty, Map.empty))
+      Right(ServerState(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty))
     else
       Try {
         val content = Files.readString(path)
         val stateJson = upickle.default.read[StateJson](content)
-        ServerState(stateJson.worktrees, stateJson.issueCache, stateJson.progressCache, stateJson.prCache)
+        ServerState(stateJson.worktrees, stateJson.issueCache, stateJson.progressCache, stateJson.prCache, stateJson.reviewStateCache)
       } match
         case Success(state) => Right(state)
         case Failure(ex) => Left(s"Failed to parse JSON from $statePath: ${ex.getMessage}")
@@ -68,7 +74,7 @@ case class StateRepository(statePath: String):
     Try {
       ensureDirectoryExists()
 
-      val stateJson = StateJson(state.worktrees, state.issueCache, state.progressCache, state.prCache)
+      val stateJson = StateJson(state.worktrees, state.issueCache, state.progressCache, state.prCache, state.reviewStateCache)
       val json = upickle.default.write(stateJson, indent = 2)
 
       // Atomic write: write to temp file, then rename

--- a/.iw/core/WorktreeListView.scala
+++ b/.iw/core/WorktreeListView.scala
@@ -3,20 +3,20 @@
 
 package iw.core.presentation.views
 
-import iw.core.domain.{WorktreeRegistration, IssueData, WorkflowProgress, GitStatus, PullRequestData}
+import iw.core.domain.{WorktreeRegistration, IssueData, WorkflowProgress, GitStatus, PullRequestData, ReviewState}
 import scalatags.Text.all.*
 import java.time.Instant
 import java.time.Duration
 
 object WorktreeListView:
-  /** Render worktree list with issue data, progress, git status, and PR data.
+  /** Render worktree list with issue data, progress, git status, PR data, and review state.
     *
-    * @param worktreesWithData List of tuples (worktree, optional issue data with cache flag, optional progress, optional git status, optional PR data)
+    * @param worktreesWithData List of tuples (worktree, optional issue data with cache flag, optional progress, optional git status, optional PR data, optional review state)
     * @param now Current timestamp for relative time formatting
     * @return HTML fragment
     */
   def render(
-    worktreesWithData: List[(WorktreeRegistration, Option[(IssueData, Boolean)], Option[WorkflowProgress], Option[GitStatus], Option[PullRequestData])],
+    worktreesWithData: List[(WorktreeRegistration, Option[(IssueData, Boolean)], Option[WorkflowProgress], Option[GitStatus], Option[PullRequestData], Option[ReviewState])],
     now: Instant
   ): Frag =
     if worktreesWithData.isEmpty then
@@ -27,8 +27,8 @@ object WorktreeListView:
     else
       div(
         cls := "worktree-list",
-        worktreesWithData.map { case (wt, issueData, progress, gitStatus, prData) =>
-          renderWorktreeCard(wt, issueData, progress, gitStatus, prData, now)
+        worktreesWithData.map { case (wt, issueData, progress, gitStatus, prData, reviewState) =>
+          renderWorktreeCard(wt, issueData, progress, gitStatus, prData, reviewState, now)
         }
       )
 
@@ -38,6 +38,7 @@ object WorktreeListView:
     progress: Option[WorkflowProgress],
     gitStatus: Option[GitStatus],
     prData: Option[PullRequestData],
+    reviewState: Option[ReviewState],
     now: Instant
   ): Frag =
     div(
@@ -121,6 +122,19 @@ object WorktreeListView:
             )
           else
             ()
+        )
+      },
+      // Review artifacts section (if available)
+      reviewState.filter(_.artifacts.nonEmpty).map { state =>
+        div(
+          cls := "review-artifacts",
+          h4("Review Artifacts"),
+          ul(
+            cls := "artifact-list",
+            state.artifacts.map { artifact =>
+              li(artifact.label)
+            }
+          )
         )
       },
       // Last activity

--- a/.iw/core/test/CachedReviewStateTest.scala
+++ b/.iw/core/test/CachedReviewStateTest.scala
@@ -1,0 +1,56 @@
+// PURPOSE: Unit tests for CachedReviewState cache validation logic
+// PURPOSE: Verify mtime-based cache invalidation
+
+package iw.core.test
+
+import iw.core.domain.{CachedReviewState, ReviewState, ReviewArtifact}
+
+class CachedReviewStateTest extends munit.FunSuite:
+
+  val sampleState = ReviewState(
+    status = Some("awaiting_review"),
+    phase = Some(1),
+    message = Some("Ready"),
+    artifacts = List(ReviewArtifact("Doc", "path/to/doc.md"))
+  )
+
+  test("CachedReviewState.isValid returns true when mtimes match"):
+    val filesMtime = Map("file1.json" -> 1000L, "file2.json" -> 2000L)
+    val cached = CachedReviewState(sampleState, filesMtime)
+
+    val currentMtimes = Map("file1.json" -> 1000L, "file2.json" -> 2000L)
+    assert(CachedReviewState.isValid(cached, currentMtimes))
+
+  test("CachedReviewState.isValid returns false when mtime changed"):
+    val filesMtime = Map("file1.json" -> 1000L)
+    val cached = CachedReviewState(sampleState, filesMtime)
+
+    val currentMtimes = Map("file1.json" -> 2000L) // mtime changed
+    assert(!CachedReviewState.isValid(cached, currentMtimes))
+
+  test("CachedReviewState.isValid returns false when file added"):
+    val filesMtime = Map("file1.json" -> 1000L)
+    val cached = CachedReviewState(sampleState, filesMtime)
+
+    val currentMtimes = Map("file1.json" -> 1000L, "file2.json" -> 2000L) // new file
+    assert(!CachedReviewState.isValid(cached, currentMtimes))
+
+  test("CachedReviewState.isValid returns false when file removed"):
+    val filesMtime = Map("file1.json" -> 1000L, "file2.json" -> 2000L)
+    val cached = CachedReviewState(sampleState, filesMtime)
+
+    val currentMtimes = Map("file1.json" -> 1000L) // file2 removed
+    assert(!CachedReviewState.isValid(cached, currentMtimes))
+
+  test("CachedReviewState.isValid returns true for empty file lists"):
+    val cached = CachedReviewState(sampleState, Map.empty)
+    val currentMtimes = Map.empty[String, Long]
+
+    assert(CachedReviewState.isValid(cached, currentMtimes))
+
+  test("CachedReviewState.isValid returns false when multiple mtimes changed"):
+    val filesMtime = Map("file1.json" -> 1000L, "file2.json" -> 2000L, "file3.json" -> 3000L)
+    val cached = CachedReviewState(sampleState, filesMtime)
+
+    val currentMtimes = Map("file1.json" -> 1500L, "file2.json" -> 2500L, "file3.json" -> 3000L)
+    assert(!CachedReviewState.isValid(cached, currentMtimes))

--- a/.iw/core/test/DashboardServiceTest.scala
+++ b/.iw/core/test/DashboardServiceTest.scala
@@ -1,0 +1,162 @@
+// PURPOSE: Unit tests for DashboardService application logic
+// PURPOSE: Tests review state integration in dashboard rendering
+
+package iw.core.application
+
+import munit.FunSuite
+import iw.core.domain.{
+  WorktreeRegistration,
+  ReviewState,
+  ReviewArtifact,
+  CachedReviewState,
+  CachedIssue,
+  CachedProgress,
+  CachedPR
+}
+import java.time.Instant
+
+class DashboardServiceTest extends FunSuite:
+
+  // Test fixtures
+  private val now = Instant.now()
+
+  private def createWorktree(
+    issueId: String,
+    path: String = "/path/to/worktree"
+  ): WorktreeRegistration =
+    WorktreeRegistration(
+      issueId = issueId,
+      path = path,
+      trackerType = "linear",
+      team = "IWLE",
+      registeredAt = now,
+      lastSeenAt = now
+    )
+
+  // Review State Integration Tests
+
+  test("renderDashboard includes review state when present in cache"):
+    val worktree = createWorktree("IWLE-123")
+    val reviewState = ReviewState(
+      status = Some("awaiting_review"),
+      phase = Some(3),
+      message = Some("Ready for code review"),
+      artifacts = List(
+        ReviewArtifact("Analysis", "project-management/issues/IWLE-123/analysis.md"),
+        ReviewArtifact("Tasks", "project-management/issues/IWLE-123/tasks.md")
+      )
+    )
+    val reviewStateCache = Map(
+      "IWLE-123" -> CachedReviewState(
+        reviewState,
+        Map("/path/to/worktree/project-management/issues/IWLE-123/review-state.json" -> 1000L)
+      )
+    )
+
+    val html = DashboardService.renderDashboard(
+      worktrees = List(worktree),
+      issueCache = Map.empty,
+      progressCache = Map.empty,
+      prCache = Map.empty,
+      reviewStateCache = reviewStateCache,
+      config = None
+    )
+
+    // Verify dashboard was rendered (basic check)
+    assert(html.contains("<!DOCTYPE html>"))
+    assert(html.contains("iw Dashboard"))
+    assert(html.contains("IWLE-123"))
+
+  test("renderDashboard handles missing review state gracefully"):
+    val worktree = createWorktree("IWLE-456")
+
+    val html = DashboardService.renderDashboard(
+      worktrees = List(worktree),
+      issueCache = Map.empty,
+      progressCache = Map.empty,
+      prCache = Map.empty,
+      reviewStateCache = Map.empty, // No cached review state
+      config = None
+    )
+
+    // Verify dashboard was rendered without errors
+    assert(html.contains("<!DOCTYPE html>"))
+    assert(html.contains("IWLE-456"))
+
+  test("renderDashboard with empty worktree list"):
+    val html = DashboardService.renderDashboard(
+      worktrees = List.empty,
+      issueCache = Map.empty,
+      progressCache = Map.empty,
+      prCache = Map.empty,
+      reviewStateCache = Map.empty,
+      config = None
+    )
+
+    // Verify empty state is rendered
+    assert(html.contains("<!DOCTYPE html>"))
+    assert(html.contains("iw Dashboard"))
+
+  test("renderDashboard with multiple worktrees and mixed review state availability"):
+    val worktree1 = createWorktree("IWLE-100", "/path1")
+    val worktree2 = createWorktree("IWLE-200", "/path2")
+    val worktree3 = createWorktree("IWLE-300", "/path3")
+
+    val reviewState = ReviewState(
+      status = Some("in_progress"),
+      phase = Some(2),
+      message = None,
+      artifacts = List(ReviewArtifact("Context", "context.md"))
+    )
+
+    // Only worktree2 has cached review state
+    val reviewStateCache = Map(
+      "IWLE-200" -> CachedReviewState(
+        reviewState,
+        Map("/path2/project-management/issues/IWLE-200/review-state.json" -> 1000L)
+      )
+    )
+
+    val html = DashboardService.renderDashboard(
+      worktrees = List(worktree1, worktree2, worktree3),
+      issueCache = Map.empty,
+      progressCache = Map.empty,
+      prCache = Map.empty,
+      reviewStateCache = reviewStateCache,
+      config = None
+    )
+
+    // Verify all worktrees are rendered
+    assert(html.contains("IWLE-100"))
+    assert(html.contains("IWLE-200"))
+    assert(html.contains("IWLE-300"))
+
+  test("renderDashboard review state cache is keyed by issue ID"):
+    val worktree = createWorktree("IWLE-789")
+
+    // Cache entry with different issue ID should not match
+    val reviewState = ReviewState(
+      status = Some("completed"),
+      phase = Some(5),
+      message = Some("All done"),
+      artifacts = List.empty
+    )
+    val reviewStateCache = Map(
+      "IWLE-DIFFERENT" -> CachedReviewState(
+        reviewState,
+        Map("/path/review-state.json" -> 1000L)
+      )
+    )
+
+    val html = DashboardService.renderDashboard(
+      worktrees = List(worktree),
+      issueCache = Map.empty,
+      progressCache = Map.empty,
+      prCache = Map.empty,
+      reviewStateCache = reviewStateCache, // Wrong issue ID
+      config = None
+    )
+
+    // Dashboard should render without the cached review state
+    assert(html.contains("<!DOCTYPE html>"))
+    assert(html.contains("IWLE-789"))

--- a/.iw/core/test/ReviewStateServiceTest.scala
+++ b/.iw/core/test/ReviewStateServiceTest.scala
@@ -1,0 +1,202 @@
+// PURPOSE: Unit and integration tests for ReviewStateService
+// PURPOSE: Verify JSON parsing and file I/O with caching
+
+package iw.core.test
+
+import iw.core.application.ReviewStateService
+import iw.core.domain.{ReviewState, ReviewArtifact, CachedReviewState}
+
+class ReviewStateServiceTest extends munit.FunSuite:
+
+  // JSON Parsing Tests
+
+  test("parseReviewStateJson parses valid JSON with all fields"):
+    val json = """{
+      "status": "awaiting_review",
+      "phase": 8,
+      "message": "Ready for review",
+      "artifacts": [
+        {"label": "Analysis", "path": "project-management/issues/46/analysis.md"}
+      ]
+    }"""
+
+    val result = ReviewStateService.parseReviewStateJson(json)
+    assert(result.isRight)
+
+    val state = result.toOption.get
+    assertEquals(state.status, Some("awaiting_review"))
+    assertEquals(state.phase, Some(8))
+    assertEquals(state.message, Some("Ready for review"))
+    assertEquals(state.artifacts.size, 1)
+    assertEquals(state.artifacts.head.label, "Analysis")
+    assertEquals(state.artifacts.head.path, "project-management/issues/46/analysis.md")
+
+  test("parseReviewStateJson parses minimal JSON (only artifacts)"):
+    val json = """{
+      "artifacts": [
+        {"label": "Doc", "path": "path/to/doc.md"}
+      ]
+    }"""
+
+    val result = ReviewStateService.parseReviewStateJson(json)
+    assert(result.isRight)
+
+    val state = result.toOption.get
+    assertEquals(state.status, None)
+    assertEquals(state.phase, None)
+    assertEquals(state.message, None)
+    assertEquals(state.artifacts.size, 1)
+    assertEquals(state.artifacts.head.label, "Doc")
+
+  test("parseReviewStateJson returns error for missing artifacts"):
+    val json = """{
+      "status": "awaiting_review"
+    }"""
+
+    val result = ReviewStateService.parseReviewStateJson(json)
+    assert(result.isLeft)
+    // Just verify it's an error - the specific message may vary
+    assert(result.left.exists(_.nonEmpty))
+
+  test("parseReviewStateJson returns error for invalid JSON syntax"):
+    val json = """{ invalid json }"""
+
+    val result = ReviewStateService.parseReviewStateJson(json)
+    assert(result.isLeft)
+
+  test("parseReviewStateJson handles optional fields as None"):
+    val json = """{
+      "artifacts": [
+        {"label": "Test", "path": "test.md"}
+      ]
+    }"""
+
+    val result = ReviewStateService.parseReviewStateJson(json)
+    assert(result.isRight)
+
+    val state = result.toOption.get
+    assertEquals(state.status, None)
+    assertEquals(state.phase, None)
+    assertEquals(state.message, None)
+
+  test("parseReviewStateJson handles multiple artifacts"):
+    val json = """{
+      "artifacts": [
+        {"label": "Analysis", "path": "analysis.md"},
+        {"label": "Context", "path": "context.md"},
+        {"label": "Tasks", "path": "tasks.md"}
+      ]
+    }"""
+
+    val result = ReviewStateService.parseReviewStateJson(json)
+    assert(result.isRight)
+
+    val state = result.toOption.get
+    assertEquals(state.artifacts.size, 3)
+    assertEquals(state.artifacts.map(_.label), List("Analysis", "Context", "Tasks"))
+
+  test("parseReviewStateJson handles empty artifacts list"):
+    val json = """{
+      "artifacts": []
+    }"""
+
+    val result = ReviewStateService.parseReviewStateJson(json)
+    assert(result.isRight)
+
+    val state = result.toOption.get
+    assertEquals(state.artifacts.size, 0)
+
+  // fetchReviewState Tests
+
+  test("fetchReviewState returns cached state when mtime unchanged"):
+    val issueId = "IWLE-123"
+    val worktreePath = "/path/to/worktree"
+    val reviewStatePath = s"$worktreePath/project-management/issues/$issueId/review-state.json"
+
+    val cachedState = ReviewState(
+      status = Some("cached"),
+      phase = Some(1),
+      message = None,
+      artifacts = List(ReviewArtifact("Cached", "cached.md"))
+    )
+    val cache = Map(
+      issueId -> CachedReviewState(cachedState, Map(reviewStatePath -> 1000L))
+    )
+
+    // Mock I/O: return same mtime
+    val getMtime = (path: String) => Right(1000L)
+    val readFile = (path: String) => fail("File should not be read when cache is valid")
+
+    val result = ReviewStateService.fetchReviewState(issueId, worktreePath, cache, readFile, getMtime)
+    assert(result.isRight)
+    assertEquals(result.toOption.get, cachedState)
+
+  test("fetchReviewState re-reads file when mtime changed"):
+    val issueId = "IWLE-123"
+    val worktreePath = "/path/to/worktree"
+    val reviewStatePath = s"$worktreePath/project-management/issues/$issueId/review-state.json"
+
+    val oldState = ReviewState(None, None, None, List(ReviewArtifact("Old", "old.md")))
+    val cache = Map(
+      issueId -> CachedReviewState(oldState, Map(reviewStatePath -> 1000L))
+    )
+
+    val newJson = """{
+      "artifacts": [{"label": "New", "path": "new.md"}]
+    }"""
+
+    // Mock I/O: mtime changed, file has new content
+    val getMtime = (path: String) => Right(2000L) // Changed mtime
+    val readFile = (path: String) => Right(newJson)
+
+    val result = ReviewStateService.fetchReviewState(issueId, worktreePath, cache, readFile, getMtime)
+    assert(result.isRight)
+
+    val state = result.toOption.get
+    assertEquals(state.artifacts.head.label, "New")
+
+  test("fetchReviewState returns error for missing file"):
+    val issueId = "IWLE-123"
+    val worktreePath = "/path/to/worktree"
+    val cache = Map.empty[String, CachedReviewState]
+
+    // Mock I/O: file doesn't exist
+    val getMtime = (path: String) => Left("File not found")
+    val readFile = (path: String) => Left("File not found")
+
+    val result = ReviewStateService.fetchReviewState(issueId, worktreePath, cache, readFile, getMtime)
+    assert(result.isLeft)
+
+  test("fetchReviewState returns error for invalid JSON"):
+    val issueId = "IWLE-123"
+    val worktreePath = "/path/to/worktree"
+    val cache = Map.empty[String, CachedReviewState]
+
+    val invalidJson = """{ invalid }"""
+
+    // Mock I/O: file exists with invalid content
+    val getMtime = (path: String) => Right(1000L)
+    val readFile = (path: String) => Right(invalidJson)
+
+    val result = ReviewStateService.fetchReviewState(issueId, worktreePath, cache, readFile, getMtime)
+    assert(result.isLeft)
+
+  test("fetchReviewState handles cache miss (reads and parses file)"):
+    val issueId = "IWLE-123"
+    val worktreePath = "/path/to/worktree"
+    val cache = Map.empty[String, CachedReviewState] // Empty cache
+
+    val validJson = """{
+      "artifacts": [{"label": "Test", "path": "test.md"}]
+    }"""
+
+    // Mock I/O
+    val getMtime = (path: String) => Right(1000L)
+    val readFile = (path: String) => Right(validJson)
+
+    val result = ReviewStateService.fetchReviewState(issueId, worktreePath, cache, readFile, getMtime)
+    assert(result.isRight)
+
+    val state = result.toOption.get
+    assertEquals(state.artifacts.size, 1)
+    assertEquals(state.artifacts.head.label, "Test")

--- a/.iw/core/test/ReviewStateTest.scala
+++ b/.iw/core/test/ReviewStateTest.scala
@@ -1,0 +1,56 @@
+// PURPOSE: Unit tests for ReviewState and ReviewArtifact domain models
+// PURPOSE: Verify structure and basic properties of review state data
+
+package iw.core.test
+
+import iw.core.domain.{ReviewState, ReviewArtifact}
+
+class ReviewStateTest extends munit.FunSuite:
+
+  test("ReviewState requires artifacts list"):
+    val artifact = ReviewArtifact("Analysis", "project-management/issues/46/analysis.md")
+    val state = ReviewState(
+      status = Some("awaiting_review"),
+      phase = Some(8),
+      message = Some("Ready for review"),
+      artifacts = List(artifact)
+    )
+
+    assertEquals(state.artifacts.size, 1)
+    assertEquals(state.artifacts.head, artifact)
+
+  test("ReviewState accepts optional status, phase, message"):
+    val artifact = ReviewArtifact("Doc", "path/to/doc.md")
+    val minimalState = ReviewState(
+      status = None,
+      phase = None,
+      message = None,
+      artifacts = List(artifact)
+    )
+
+    assertEquals(minimalState.status, None)
+    assertEquals(minimalState.phase, None)
+    assertEquals(minimalState.message, None)
+    assertEquals(minimalState.artifacts.size, 1)
+
+  test("ReviewArtifact has label and path"):
+    val artifact = ReviewArtifact("Analysis", "project-management/issues/46/analysis.md")
+
+    assertEquals(artifact.label, "Analysis")
+    assertEquals(artifact.path, "project-management/issues/46/analysis.md")
+
+  test("ReviewState can have multiple artifacts"):
+    val artifacts = List(
+      ReviewArtifact("Analysis", "path/to/analysis.md"),
+      ReviewArtifact("Context", "path/to/context.md"),
+      ReviewArtifact("Tasks", "path/to/tasks.md")
+    )
+    val state = ReviewState(None, None, None, artifacts)
+
+    assertEquals(state.artifacts.size, 3)
+    assertEquals(state.artifacts.map(_.label), List("Analysis", "Context", "Tasks"))
+
+  test("ReviewState can have empty artifacts list"):
+    val state = ReviewState(None, None, None, List.empty)
+
+    assertEquals(state.artifacts.size, 0)

--- a/.iw/core/test/ServerStateTest.scala
+++ b/.iw/core/test/ServerStateTest.scala
@@ -147,5 +147,41 @@ class ServerStateTest extends munit.FunSuite:
       worktrees = state.worktrees - "IWLE-999",
       issueCache = state.issueCache - "IWLE-999",
       progressCache = state.progressCache - "IWLE-999",
-      prCache = state.prCache - "IWLE-999"
+      prCache = state.prCache - "IWLE-999",
+      reviewStateCache = state.reviewStateCache - "IWLE-999"
     ))
+
+  test("ServerState includes reviewStateCache field"):
+    val state = ServerState(
+      worktrees = Map.empty,
+      issueCache = Map.empty,
+      progressCache = Map.empty,
+      prCache = Map.empty,
+      reviewStateCache = Map.empty
+    )
+
+    assertEquals(state.reviewStateCache.size, 0)
+
+  test("ServerState.removeWorktree clears review state cache entry"):
+    val now = Instant.now()
+    val worktree = WorktreeRegistration(
+      issueId = "IWLE-123",
+      path = "/path",
+      trackerType = "linear",
+      team = "IWLE",
+      registeredAt = now,
+      lastSeenAt = now
+    )
+    val reviewStateCache = Map("IWLE-123" -> iw.core.domain.CachedReviewState(
+      iw.core.domain.ReviewState(None, None, None, List.empty),
+      Map.empty
+    ))
+
+    val state = ServerState(
+      worktrees = Map("IWLE-123" -> worktree),
+      reviewStateCache = reviewStateCache
+    )
+
+    val newState = state.removeWorktree("IWLE-123")
+
+    assert(!newState.reviewStateCache.contains("IWLE-123"))

--- a/.iw/core/test/WorktreeListViewTest.scala
+++ b/.iw/core/test/WorktreeListViewTest.scala
@@ -1,0 +1,140 @@
+// PURPOSE: Unit tests for WorktreeListView rendering
+// PURPOSE: Verify HTML output for worktree cards including review artifacts section
+
+package iw.core.test
+
+import iw.core.domain.{WorktreeRegistration, IssueData, WorkflowProgress, GitStatus, PullRequestData, ReviewState, ReviewArtifact}
+import iw.core.presentation.views.WorktreeListView
+import java.time.Instant
+
+class WorktreeListViewTest extends munit.FunSuite:
+
+  val now = Instant.parse("2025-01-15T12:00:00Z")
+
+  val sampleWorktree = WorktreeRegistration(
+    issueId = "IWLE-123",
+    path = "/path/to/worktree",
+    trackerType = "Linear",
+    team = "Engineering",
+    registeredAt = Instant.parse("2025-01-10T10:00:00Z"),
+    lastSeenAt = Instant.parse("2025-01-15T11:00:00Z")
+  )
+
+  val sampleIssueData = IssueData(
+    id = "IWLE-123",
+    title = "Test Issue",
+    status = "In Progress",
+    assignee = Some("Developer"),
+    description = Some("Test issue description"),
+    url = "https://linear.app/issue/IWLE-123",
+    fetchedAt = Instant.parse("2025-01-15T11:30:00Z")
+  )
+
+  // Review Artifacts Section Tests
+
+  test("WorktreeListView renders review section when reviewState provided with artifacts"):
+    val reviewState = Some(ReviewState(
+      status = Some("awaiting_review"),
+      phase = Some(1),
+      message = Some("Ready for review"),
+      artifacts = List(
+        ReviewArtifact("Analysis", "project-management/issues/IWLE-123/analysis.md"),
+        ReviewArtifact("Context", "project-management/issues/IWLE-123/phase-01-context.md")
+      )
+    ))
+
+    val worktreesWithData = List(
+      (sampleWorktree, Some((sampleIssueData, false)), None, None, None, reviewState)
+    )
+
+    val html = WorktreeListView.render(worktreesWithData, now)
+    val htmlStr = html.render
+
+    assert(htmlStr.contains("Review Artifacts"), s"Should contain 'Review Artifacts' heading")
+    assert(htmlStr.contains("review-artifacts"), s"Should contain 'review-artifacts' class")
+    assert(htmlStr.contains("artifact-list"), s"Should contain 'artifact-list' class")
+    assert(htmlStr.contains("Analysis"), s"Should contain artifact label 'Analysis'")
+    assert(htmlStr.contains("Context"), s"Should contain artifact label 'Context'")
+
+  test("WorktreeListView omits review section when reviewState is None"):
+    val worktreesWithData = List(
+      (sampleWorktree, Some((sampleIssueData, false)), None, None, None, None)
+    )
+
+    val html = WorktreeListView.render(worktreesWithData, now)
+    val htmlStr = html.render
+
+    assert(!htmlStr.contains("Review Artifacts"), s"Should not contain 'Review Artifacts' when reviewState is None")
+    assert(!htmlStr.contains("review-artifacts"), s"Should not contain 'review-artifacts' class")
+    assert(!htmlStr.contains("artifact-list"), s"Should not contain 'artifact-list' class")
+
+  test("WorktreeListView omits review section when artifacts list is empty"):
+    val reviewState = Some(ReviewState(
+      status = Some("awaiting_review"),
+      phase = Some(1),
+      message = Some("Ready for review"),
+      artifacts = List.empty  // Empty artifacts list
+    ))
+
+    val worktreesWithData = List(
+      (sampleWorktree, Some((sampleIssueData, false)), None, None, None, reviewState)
+    )
+
+    val html = WorktreeListView.render(worktreesWithData, now)
+    val htmlStr = html.render
+
+    assert(!htmlStr.contains("Review Artifacts"), s"Should not contain 'Review Artifacts' when artifacts list is empty")
+    assert(!htmlStr.contains("review-artifacts"), s"Should not contain 'review-artifacts' class")
+
+  test("WorktreeListView displays all artifact labels correctly"):
+    val reviewState = Some(ReviewState(
+      status = None,
+      phase = None,
+      message = None,
+      artifacts = List(
+        ReviewArtifact("Analysis Doc", "path/to/analysis.md"),
+        ReviewArtifact("Phase Context", "path/to/context.md"),
+        ReviewArtifact("Review Packet", "path/to/review-packet.md")
+      )
+    ))
+
+    val worktreesWithData = List(
+      (sampleWorktree, Some((sampleIssueData, false)), None, None, None, reviewState)
+    )
+
+    val html = WorktreeListView.render(worktreesWithData, now)
+    val htmlStr = html.render
+
+    assert(htmlStr.contains("Analysis Doc"), s"Should contain artifact label 'Analysis Doc'")
+    assert(htmlStr.contains("Phase Context"), s"Should contain artifact label 'Phase Context'")
+    assert(htmlStr.contains("Review Packet"), s"Should contain artifact label 'Review Packet'")
+    // Verify all are within list items
+    assert(htmlStr.contains("<li>Analysis Doc</li>"), s"Artifacts should be in list items")
+
+  test("WorktreeListView renders empty state when no worktrees"):
+    val html = WorktreeListView.render(List.empty, now)
+    val htmlStr = html.render
+
+    assert(htmlStr.contains("empty-state"), s"Should contain 'empty-state' class")
+    assert(htmlStr.contains("No worktrees registered yet"), s"Should show empty state message")
+
+  test("WorktreeListView renders multiple worktrees with different review states"):
+    val wt1 = sampleWorktree.copy(issueId = "IWLE-1")
+    val wt2 = sampleWorktree.copy(issueId = "IWLE-2")
+
+    val reviewState1 = Some(ReviewState(None, None, None, List(ReviewArtifact("Doc1", "doc1.md"))))
+    val reviewState2 = None  // No review state
+
+    val worktreesWithData = List(
+      (wt1, Some((sampleIssueData, false)), None, None, None, reviewState1),
+      (wt2, Some((sampleIssueData, false)), None, None, None, reviewState2)
+    )
+
+    val html = WorktreeListView.render(worktreesWithData, now)
+    val htmlStr = html.render
+
+    // Should have one review section (for wt1) but not for wt2
+    assert(htmlStr.contains("Doc1"), s"Should contain artifact for first worktree")
+    // Count occurrences of "Review Artifacts" - should be exactly 1
+    val reviewArtifactsCount = "Review Artifacts".r.findAllIn(htmlStr).length
+    assertEquals(reviewArtifactsCount, 1, s"Should have exactly one 'Review Artifacts' section")


### PR DESCRIPTION
## Phase 1: Display artifacts from state file

**Goals**: Implement foundation for displaying review artifacts in dashboard - domain models, JSON parsing, service with I/O injection, dashboard integration, and graceful degradation.

**Tests**: 49 tests (38 unit, 5 integration, 6 view)

[Full review packet](./project-management/issues/46/review-packet-phase-01.md)

### Changes
- Add ReviewState and ReviewArtifact domain models
- Add CachedReviewState with mtime-based cache validation  
- Add ReviewStateService with I/O injection pattern (FCIS)
- Extend ServerState with reviewStateCache field
- Extend StateRepository with JSON serialization
- Extend DashboardService with fetchReviewStateForWorktree
- Extend WorktreeListView with review artifacts section
- Update CaskServer route to pass reviewStateCache

🤖 Generated with [Claude Code](https://claude.com/claude-code)