### PR TITLE
fix(dashboard): Use canonical issue IDs without # prefix for GitHub

### DIFF
--- a/.iw/core/GitHubClient.scala
+++ b/.iw/core/GitHubClient.scala
@@ -338,9 +338,9 @@ object GitHubClient:
       // Parse array of issues
       val issuesArray = json.arr
       val issues = issuesArray.map { issueJson =>
-        // Format issue ID with # prefix (e.g., "#132")
+        // Use bare issue number as canonical ID (consistent with other trackers)
         val number = issueJson("number").num.toInt
-        val id = s"#$number"
+        val id = number.toString
 
         // Extract title and state (lowercase state for consistency)
         val title = issueJson("title").str

--- a/.iw/core/test/GitHubClientTest.scala
+++ b/.iw/core/test/GitHubClientTest.scala
@@ -601,12 +601,12 @@ class GitHubClientTest extends munit.FunSuite:
     assert(result.isRight)
     val issues = result.getOrElse(fail("Expected Right"))
     assertEquals(issues.length, 3)
-    assertEquals(issues(0).id, "#132")
+    assertEquals(issues(0).id, "132")
     assertEquals(issues(0).title, "Add feature")
     assertEquals(issues(0).status, "open")
-    assertEquals(issues(1).id, "#131")
+    assertEquals(issues(1).id, "131")
     assertEquals(issues(1).title, "Fix bug")
-    assertEquals(issues(2).id, "#130")
+    assertEquals(issues(2).id, "130")
     assertEquals(issues(2).title, "Update docs")
 
   test("parseListRecentIssuesResponse parses empty array"):
@@ -656,7 +656,7 @@ class GitHubClientTest extends munit.FunSuite:
     assert(result.isRight)
     val issues = result.getOrElse(fail("Expected Right"))
     assertEquals(issues.length, 2)
-    assertEquals(issues(0).id, "#132")
+    assertEquals(issues(0).id, "132")
     assertEquals(issues(0).title, "Add feature")
 
   test("listRecentIssues fails when gh CLI not available"):
@@ -748,9 +748,9 @@ class GitHubClientTest extends munit.FunSuite:
     assert(result.isRight)
     val issues = result.getOrElse(fail("Expected Right"))
     assertEquals(issues.length, 2)
-    assertEquals(issues(0).id, "#132")
+    assertEquals(issues(0).id, "132")
     assertEquals(issues(0).title, "Add feature")
-    assertEquals(issues(1).id, "#131")
+    assertEquals(issues(1).id, "131")
     assertEquals(issues(1).title, "Fix bug")
 
   // ========== searchIssues Integration Tests ==========
@@ -779,7 +779,7 @@ class GitHubClientTest extends munit.FunSuite:
     assert(result.isRight)
     val issues = result.getOrElse(fail("Expected Right"))
     assertEquals(issues.length, 2)
-    assertEquals(issues(0).id, "#132")
+    assertEquals(issues(0).id, "132")
     assertEquals(issues(0).title, "Fix authentication bug")
 
   test("searchIssues when gh CLI not available"):


### PR DESCRIPTION
## Summary
- Fixed GitHub issue IDs being prefixed with `#` (e.g., `#132` instead of `132`)
- This caused "Issue Not Found" errors when clicking issues in the dashboard modal
- Changed `parseListRecentIssuesResponse` to use bare issue numbers as canonical IDs

## Test plan
- [x] Unit tests updated and passing
- [x] Verified in browser: issue IDs now display as `32`, `31`, `30` instead of `#32`, `#31`, `#30`
- [x] Clicking an issue now correctly creates a worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)