### PR TITLE
fix(dashboard): Handle non-2xx HTTP responses in HTMX modal

### DIFF
--- a/.iw/core/DashboardService.scala
+++ b/.iw/core/DashboardService.scala
@@ -68,6 +68,10 @@ object DashboardService:
           attr("integrity") := "sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC",
           attr("crossorigin") := "anonymous"
         ),
+        // Add HTMX response-targets extension for error status code handling
+        tag("script")(
+          src := "https://unpkg.com/htmx-ext-response-targets@2.0.0/response-targets.js"
+        ),
         tag("script")(raw("""
           document.addEventListener('visibilitychange', function() {
             if (document.visibilityState === 'visible') {
@@ -78,6 +82,7 @@ object DashboardService:
         tag("style")(raw(styles))
       ),
       body(
+        attr("hx-ext") := "response-targets",
         div(
           cls := "container",
           // Header with title and SSH host configuration

--- a/.iw/core/presentation/views/CreationErrorView.scala
+++ b/.iw/core/presentation/views/CreationErrorView.scala
@@ -78,6 +78,8 @@ object CreationErrorView:
       cls := "btn-primary retry-btn",
       attr("hx-post") := "/api/worktrees/create",
       attr("hx-target") := "#modal-body-content",
+      attr("hx-target-4xx") := "#modal-body-content",
+      attr("hx-target-5xx") := "#modal-body-content",
       attr("hx-swap") := "innerHTML",
       attr("hx-indicator") := "#creation-spinner"
     )

--- a/.iw/core/presentation/views/SearchResultsView.scala
+++ b/.iw/core/presentation/views/SearchResultsView.scala
@@ -81,6 +81,8 @@ object SearchResultsView:
         attr("hx-post") := "/api/worktrees/create",
         attr("hx-vals") := valsJson,
         attr("hx-target") := "#modal-body-content",
+        attr("hx-target-4xx") := "#modal-body-content",
+        attr("hx-target-5xx") := "#modal-body-content",
         attr("hx-swap") := "innerHTML",
         attr("hx-indicator") := "#creation-spinner"
       )

--- a/.iw/core/test/CreationErrorViewTest.scala
+++ b/.iw/core/test/CreationErrorViewTest.scala
@@ -134,3 +134,9 @@ class CreationErrorViewTest extends FunSuite:
 
     assert(html.contains("Retry") || html.contains("Try Again"), "Should have retry button")
     assert(!html.contains("hx-vals"), "Should not have hx-vals when issueId is None")
+
+  test("retry button has hx-target-4xx and hx-target-5xx for error response handling"):
+    val html = CreationErrorView.render(errorWithRetry).render
+
+    assert(html.contains("hx-target-4xx"), "Should have hx-target-4xx attribute")
+    assert(html.contains("hx-target-5xx"), "Should have hx-target-5xx attribute")

--- a/.iw/core/test/SearchResultsViewTest.scala
+++ b/.iw/core/test/SearchResultsViewTest.scala
@@ -190,3 +190,11 @@ class SearchResultsViewTest extends FunSuite:
 
     assert(html.contains("hx-on::after-request"), "Should have after-request handler")
     assert(html.contains("classList.remove('disabled')"), "Should remove disabled class on request end")
+
+  test("result item has hx-target-4xx for error response handling"):
+    val result = IssueSearchResult("TEST-1", "Title", "Status", "url")
+
+    val html = SearchResultsView.render(List(result)).render
+
+    assert(html.contains("hx-target-4xx"), "Should have hx-target-4xx attribute")
+    assert(html.contains("hx-target-5xx"), "Should have hx-target-5xx attribute")


### PR DESCRIPTION
## Summary
- Added HTMX response-targets extension to properly display error HTML when worktree creation fails
- Previously, HTMX would not swap content for non-2xx responses, causing error messages to silently fail

## Changes
- Added `response-targets` extension script to DashboardService
- Added `hx-ext="response-targets"` to body element  
- Added `hx-target-4xx` and `hx-target-5xx` attributes to result items and retry button

## Test plan
- [x] Unit tests added and passing
- [x] Verified error responses now display correctly in modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)