### PR TITLE
Phase 6: GitLab issue creation

### DIFF
--- a/project-management/issues/IW-103/implementation-log.md
+++ b/project-management/issues/IW-103/implementation-log.md
@@ -184,3 +184,45 @@ M  .iw/test/issue-create.bats
 ```
 
 ---
+
+## Phase 6: GitLab issue creation (2026-01-25)
+
+**What was built:**
+- Feature: `.iw/commands/issue.scala` - Added GitLab tracker support to handleCreateSubcommand
+- Helper: `createGitLabIssue()` function for GitLab-specific issue creation flow
+- Tests: `.iw/test/issue-create.bats` - 3 new GitLab E2E tests
+
+**Decisions made:**
+- Reuse existing `GitLabClient.validateGlabPrerequisites()` for CLI validation
+- Use `GitLabClient.buildCreateIssueCommandWithoutLabel()` to build glab command
+- Pass command as array to `CommandRunner.execute("glab", args)` (not split like GitHub)
+- Follow same error handling pattern as GitHub for consistency
+
+**Patterns applied:**
+- CLI prerequisite validation: Check glab installed and authenticated before API call
+- Tracker type branching: Added `case IssueTrackerType.GitLab` alongside GitHub/Linear
+- Helper function extraction: `createGitLabIssue()` follows `createGitHubIssue()` pattern
+
+**Testing:**
+- E2E tests: 3 new tests (16 total in issue-create.bats)
+- Coverage: glab not installed, glab not authenticated, successful creation
+- Mocking: PATH manipulation for glab CLI (same pattern as gh)
+
+**Code review:**
+- Iterations: 1
+- Major findings: No critical issues. Code follows Scala 3 idioms correctly.
+
+**For next phases:**
+- Available utilities: `createGitLabIssue()` pattern for YouTrack
+- Extension points: Tracker type match ready for YouTrack
+- Notes: YouTrack requires implementing YouTrackClient.createIssue (new method)
+
+**Files changed:**
+```
+M  .iw/commands/issue.scala
+M  .iw/test/issue-create.bats
+A  project-management/issues/IW-103/phase-06-context.md
+A  project-management/issues/IW-103/phase-06-tasks.md
+```
+
+---

--- a/project-management/issues/IW-103/phase-06-context.md
+++ b/project-management/issues/IW-103/phase-06-context.md
@@ -1,0 +1,86 @@
+# Phase 6 Context: GitLab issue creation
+
+**Issue:** IW-103
+**Phase:** 6 - GitLab issue creation
+**Story:** Story 3 - Create GitLab issue with title and description
+
+## User Story
+
+```gherkin
+Feature: Create issue in GitLab repository
+  As a developer working in a GitLab-tracked project
+  I want to create issues via command line
+  So that I can log work without opening browser
+
+Scenario: Successfully create GitLab issue with title and description
+  Given I am in a project configured for GitLab tracker
+  And glab CLI is installed and authenticated
+  And repository is set to "company/platform/api-service"
+  When I run "./iw issue create --title 'API rate limiting' --description 'Implement rate limiting for public API'"
+  Then a new issue is created in GitLab repository
+  And the issue has title "API rate limiting"
+  And the issue has description "Implement rate limiting for public API"
+  And I see output "Issue created: #789"
+  And I see output "URL: https://gitlab.com/company/platform/api-service/-/issues/789"
+```
+
+## Acceptance Criteria
+
+- [ ] Command creates issue in configured GitLab repository
+- [ ] Returns issue number and URL
+- [ ] Works with nested repository paths (company/platform/api-service)
+- [ ] Validates glab CLI installed and authenticated
+
+## What Was Built in Previous Phases
+
+### Phase 2: GitHub issue creation
+- `IssueCreateParser` for parsing --title and --description
+- `handleCreateSubcommand()` with tracker type dispatch
+- Pattern: check tracker type, validate prerequisites, call client, format output
+- Helper: `createGitHubIssue()` function
+
+### Phase 5: Linear issue creation
+- Added `IssueTrackerType.Linear` branch to tracker type match
+- Helper: `createLinearIssue()` function
+- Pattern for API token validation via `ApiToken.fromEnv()`
+
+### Available Infrastructure
+- `GitLabClient.validateGlabPrerequisites(repository)` - Validates glab CLI prerequisites
+- `GitLabClient.buildCreateIssueCommandWithoutLabel(repository, title, description)` - Builds glab command
+- `GitLabClient.parseCreateIssueResponse(output)` - Parses response to CreatedIssue
+- `CreatedIssue` case class with `id` and `url` fields
+- `CommandRunner.execute(cmd, args)` - Executes CLI commands
+
+### GitLabClient Error Types
+- `GlabPrerequisiteError.GlabNotInstalled` - glab CLI not found
+- `GlabPrerequisiteError.GlabNotAuthenticated` - glab not logged in
+- `GlabPrerequisiteError.GlabError(msg)` - Other glab errors
+
+## Technical Approach
+
+1. In `handleCreateSubcommand()`, add `case IssueTrackerType.GitLab` branch
+2. Create `createGitLabIssue()` helper function following GitHub pattern
+3. Validate glab CLI prerequisites using `GitLabClient.validateGlabPrerequisites()`
+4. Get repository from `config.repository`
+5. Call `GitLabClient.buildCreateIssueCommandWithoutLabel()` and execute via CommandRunner
+6. Parse response with `GitLabClient.parseCreateIssueResponse()`
+7. Format output: "Issue created: #ID" and "URL: url"
+
+## Files to Modify
+
+- `.iw/commands/issue.scala` - Add GitLab tracker support
+- `.iw/test/issue-create.bats` - Add E2E tests for GitLab
+
+## Phase Scope
+
+- Add GitLab support to existing `handleCreateSubcommand()`
+- Add E2E tests with mocked glab CLI
+- Follow same error handling pattern as GitHub
+
+## Success Criteria
+
+- [ ] E2E test: `iw issue create --title "Test" --description "Body"` succeeds (GitLab tracker)
+- [ ] E2E test: `iw issue create --title "Test"` works without description (GitLab)
+- [ ] E2E test: Missing glab CLI shows error message
+- [ ] E2E test: Unauthenticated glab shows error message
+- [ ] Output shows issue number and URL after creation

--- a/project-management/issues/IW-103/phase-06-tasks.md
+++ b/project-management/issues/IW-103/phase-06-tasks.md
@@ -1,0 +1,42 @@
+# Phase 6 Tasks: GitLab issue creation
+
+**Issue:** IW-103
+**Phase:** 6 - GitLab issue creation
+**Story:** Story 3 - Create GitLab issue with title and description
+
+## Tasks
+
+### Setup
+- [x] [impl] [x] [reviewed] Review GitLabClient methods (validateGlabPrerequisites, buildCreateIssueCommandWithoutLabel, parseCreateIssueResponse)
+- [x] [impl] [x] [reviewed] Review createGitHubIssue() pattern for consistency
+
+### Tests (TDD - Write First)
+- [x] [impl] [x] [reviewed] Create E2E test: Missing glab CLI shows error message
+- [x] [impl] [x] [reviewed] Create E2E test: Unauthenticated glab shows error message
+- [x] [impl] [x] [reviewed] Create E2E test: `iw issue create --title "Test"` succeeds (GitLab tracker)
+
+### Implementation
+- [x] [impl] [x] [reviewed] Add GitLab branch to handleCreateSubcommand tracker type match
+- [x] [impl] [x] [reviewed] Create createGitLabIssue() helper function
+- [x] [impl] [x] [reviewed] Validate glab CLI prerequisites (installed, authenticated)
+- [x] [impl] [x] [reviewed] Get repository from config.repository
+- [x] [impl] [x] [reviewed] Build and execute glab command via CommandRunner
+- [x] [impl] [x] [reviewed] Parse response with GitLabClient.parseCreateIssueResponse
+- [x] [impl] [x] [reviewed] Format output: "Issue created: #ID" and "URL: url"
+- [x] [impl] [x] [reviewed] Handle error cases with appropriate error messages
+
+### Integration
+- [x] [impl] [x] [reviewed] Verify all E2E tests pass
+- [x] [impl] [x] [reviewed] Verify GitHub and Linear tests still pass (no regressions)
+
+## Success Criteria
+
+- [ ] All BATS E2E tests pass
+- [ ] `iw issue create --title "X" --description "Y"` creates GitLab issue
+- [ ] `iw issue create --title "X"` works without description
+- [ ] Output shows issue number and URL after creation
+- [ ] Missing glab CLI shows clear error
+- [ ] Unauthenticated glab shows clear error
+- [ ] No regressions in GitHub/Linear issue creation
+
+**Phase Status:** Complete


### PR DESCRIPTION
## Phase 6: GitLab issue creation

**Goals**: Enable creating issues on GitLab repositories using `iw issue create`

**Scenarios**: 3 verified
**Tests**: 3 new E2E tests (16 total in issue-create.bats)

**Changes**:
- Added `createGitLabIssue()` helper function to issue.scala
- Validates glab CLI prerequisites (installed, authenticated)
- Uses existing GitLabClient methods for command building and response parsing
- Follows same pattern as GitHub and Linear implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)