### PR TITLE
Phase 1: Fix totalPhases to use Phase Index as source of truth

### DIFF
--- a/.iw/core/dashboard/WorkflowProgressService.scala
+++ b/.iw/core/dashboard/WorkflowProgressService.scala
@@ -173,7 +173,7 @@ object WorkflowProgressService:
 
     WorkflowProgress(
       currentPhase = currentPhase,
-      totalPhases = phases.size,
+      totalPhases = if phaseIndex.nonEmpty then phaseIndex.size else phases.size,
       phases = phases,
       overallCompleted = overallCompleted,
       overallTotal = overallTotal

--- a/project-management/issues/IW-100/implementation-log.md
+++ b/project-management/issues/IW-100/implementation-log.md
@@ -1,0 +1,44 @@
+# Implementation Log: Dashboard shows incorrect total phase count
+
+**Issue:** IW-100
+
+This log tracks the evolution of implementation across phases.
+
+---
+
+## Phase 1: Fix totalPhases to use Phase Index as source of truth (2026-01-27)
+
+**What was built:**
+- Fixed `WorkflowProgressService.computeProgress` to use Phase Index as source of truth for totalPhases
+- Added fallback to file-based count when Phase Index is empty (backward compatibility)
+
+**Decisions made:**
+- Use `phaseIndex.size` when available, fall back to `phases.size` otherwise
+- Single-line conditional mirrors existing pattern in `determineCurrentPhase`
+
+**Patterns applied:**
+- Conditional fallback pattern: `if phaseIndex.nonEmpty then phaseIndex.size else phases.size`
+- Same pattern already used in `determineCurrentPhase` for consistency
+
+**Testing:**
+- Unit tests: 3 tests added
+  - Phase Index provides totalPhases (6-entry index, 3 files → totalPhases = 6)
+  - Phase Index matches file count (4-entry index, 4 files → totalPhases = 4)
+  - Empty Phase Index falls back (empty index, 3 files → totalPhases = 3)
+- All 15 existing tests continue to pass
+
+**Code review:**
+- Iterations: 1
+- Review file: review-phase-01-20260127-085500.md
+- Major findings: No critical issues or warnings. 4 suggestions (stylistic/future improvements)
+
+**For next phases:**
+- N/A (single phase issue)
+
+**Files changed:**
+```
+M	.iw/core/dashboard/WorkflowProgressService.scala
+M	.iw/core/test/WorkflowProgressServiceTest.scala
+```
+
+---

--- a/project-management/issues/IW-100/phase-01-context.md
+++ b/project-management/issues/IW-100/phase-01-context.md
@@ -87,12 +87,12 @@ All existing `WorkflowProgressServiceTest` tests should continue passing unchang
 
 ## Acceptance Criteria
 
-- [ ] `computeProgress` uses `phaseIndex.size` when `phaseIndex.nonEmpty`
-- [ ] `computeProgress` falls back to `phases.size` when `phaseIndex.isEmpty`
-- [ ] Test: 6-phase index with 3 files returns `totalPhases = 6`
-- [ ] Test: Empty phase index with 3 files returns `totalPhases = 3`
-- [ ] All existing tests pass
-- [ ] No changes to other files beyond the two listed
+- [x] `computeProgress` uses `phaseIndex.size` when `phaseIndex.nonEmpty`
+- [x] `computeProgress` falls back to `phases.size` when `phaseIndex.isEmpty`
+- [x] Test: 6-phase index with 3 files returns `totalPhases = 6`
+- [x] Test: Empty phase index with 3 files returns `totalPhases = 3`
+- [x] All existing tests pass
+- [x] No changes to other files beyond the two listed
 
 ## Implementation Notes
 

--- a/project-management/issues/IW-100/phase-01-tasks.md
+++ b/project-management/issues/IW-100/phase-01-tasks.md
@@ -2,31 +2,31 @@
 
 **Issue:** IW-100
 **Phase:** 1 of 1
-**Status:** Ready for Implementation
+**Status:** Complete
 
 ## Setup
 
-- [ ] [setup] Read current WorkflowProgressService.computeProgress implementation
-- [ ] [setup] Read existing WorkflowProgressServiceTest to understand test patterns
+- [x] [setup] Read current WorkflowProgressService.computeProgress implementation
+- [x] [setup] Read existing WorkflowProgressServiceTest to understand test patterns
 
 ## Tests (TDD - Write First)
 
-- [ ] [test] Add test: Phase Index provides totalPhases (6-entry index, 3 files → totalPhases = 6)
-- [ ] [test] Add test: Phase Index matches file count (4-entry index, 4 files → totalPhases = 4)
-- [ ] [test] Add test: Empty Phase Index falls back to file count (empty index, 3 files → totalPhases = 3)
-- [ ] [test] Run tests to confirm they fail (TDD red phase)
+- [x] [test] Add test: Phase Index provides totalPhases (6-entry index, 3 files → totalPhases = 6)
+- [x] [test] Add test: Phase Index matches file count (4-entry index, 4 files → totalPhases = 4)
+- [x] [test] Add test: Empty Phase Index falls back to file count (empty index, 3 files → totalPhases = 3)
+- [x] [test] Run tests to confirm they fail (TDD red phase)
 
 ## Implementation
 
-- [ ] [impl] Modify computeProgress to use phaseIndex.size when phaseIndex.nonEmpty
-- [ ] [impl] Run tests to confirm they pass (TDD green phase)
-- [ ] [impl] Run full test suite to verify no regressions
+- [x] [impl] Modify computeProgress to use phaseIndex.size when phaseIndex.nonEmpty
+- [x] [impl] Run tests to confirm they pass (TDD green phase)
+- [x] [impl] Run full test suite to verify no regressions
 
 ## Verification
 
-- [ ] [verify] All new tests pass
-- [ ] [verify] All existing tests pass
-- [ ] [verify] No compilation warnings
+- [x] [verify] All new tests pass
+- [x] [verify] All existing tests pass
+- [x] [verify] No compilation warnings
 
 ## Notes
 

--- a/project-management/issues/IW-100/review-packet-phase-01.md
+++ b/project-management/issues/IW-100/review-packet-phase-01.md
@@ -1,0 +1,150 @@
+# Review Packet: Phase 1 - Fix totalPhases to use Phase Index as source of truth
+
+**Issue:** IW-100
+**Phase:** 1 of 1
+**Branch:** IW-100-phase-01
+**Baseline:** a1eae2c
+
+## Goals
+
+This phase fixes the dashboard's incorrect total phase count by making the Phase Index the source of truth for `totalPhases`, while maintaining backward compatibility for issues without Phase Index sections.
+
+**What was accomplished:**
+1. Dashboard now displays correct total phase count from Phase Index
+2. Issues without Phase Index continue to work (fallback to file count)
+
+## Scenarios
+
+Based on acceptance criteria from phase-01-context.md:
+
+- [x] `computeProgress` uses `phaseIndex.size` when `phaseIndex.nonEmpty`
+- [x] `computeProgress` falls back to `phases.size` when `phaseIndex.isEmpty`
+- [x] Test: 6-phase index with 3 files returns `totalPhases = 6`
+- [x] Test: Empty phase index with 3 files returns `totalPhases = 3`
+- [x] All existing tests pass
+- [x] No changes to other files beyond the two listed
+
+## Entry Points
+
+Start reviewing from:
+
+1. **Production code change** (1 line):
+   - `.iw/core/dashboard/WorkflowProgressService.scala:176` - The fix
+
+2. **Test additions** (3 new tests):
+   - `.iw/core/test/WorkflowProgressServiceTest.scala:183-230` - New tests
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Dashboard Card                          │
+│                   "Phase 3/6: Login"                        │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ displays
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│               WorkflowProgress (model)                      │
+│  { currentPhase, totalPhases, phases[], ... }              │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ computed by
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│         WorkflowProgressService.computeProgress()          │
+│                                                             │
+│  [BEFORE]  totalPhases = phases.size                       │
+│  [AFTER]   totalPhases = if phaseIndex.nonEmpty            │
+│                            then phaseIndex.size            │
+│                            else phases.size                │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ uses
+          ┌───────────┴───────────┐
+          ▼                       ▼
+┌─────────────────┐   ┌─────────────────────────────┐
+│  phases: List   │   │  phaseIndex: List           │
+│  (from files)   │   │  (from tasks.md Phase Index)│
+│  - phase-01.md  │   │  - [ ] Phase 1: Setup       │
+│  - phase-02.md  │   │  - [ ] Phase 2: Impl        │
+│  - phase-03.md  │   │  - [ ] Phase 3: Test        │
+│  (3 files)      │   │  - [ ] Phase 4: Deploy      │
+│                 │   │  - [ ] Phase 5: Docs        │
+│                 │   │  - [ ] Phase 6: Review      │
+└─────────────────┘   └─────────────────────────────┘
+```
+
+## Flow Diagram
+
+```
+fetchProgress()
+      │
+      ▼
+  Read tasks.md
+      │
+      ▼
+  parsePhaseIndex() ──────────────────────────────────┐
+      │                                               │
+      ▼                                               │
+  Discover phase-NN-tasks.md files                    │
+      │                                               │
+      ▼                                               │
+  parsePhaseFiles() → List[PhaseInfo]                 │
+      │                                               │
+      ▼                                               │
+  computeProgress(phases, phaseIndex) ◄───────────────┘
+      │
+      ├── phaseIndex.nonEmpty?
+      │         │
+      │    ┌────┴────┐
+      │    YES       NO
+      │    │         │
+      │    ▼         ▼
+      │  phaseIndex  phases
+      │  .size       .size
+      │    │         │
+      │    └────┬────┘
+      │         ▼
+      │   totalPhases
+      │
+      ▼
+  WorkflowProgress(currentPhase, totalPhases, ...)
+```
+
+## Test Summary
+
+**New tests added:** 3
+
+| Test | Description | Verifies |
+|------|-------------|----------|
+| `computeProgress uses Phase Index size when Phase Index is non-empty (6-entry index, 3 files)` | 6 phases in index, 3 phase files → totalPhases = 6 | Phase Index is source of truth |
+| `computeProgress uses Phase Index size when it matches file count (4-entry index, 4 files)` | 4 phases in index, 4 phase files → totalPhases = 4 | Consistency when counts match |
+| `computeProgress falls back to file count when Phase Index is empty (empty index, 3 files)` | Empty index, 3 phase files → totalPhases = 3 | Backward compatibility |
+
+**Existing tests:** 12 tests continue to pass (no regressions)
+
+**Total tests:** 15 in WorkflowProgressServiceTest
+
+## Files Changed
+
+| File | Change Type | Lines | Description |
+|------|-------------|-------|-------------|
+| `.iw/core/dashboard/WorkflowProgressService.scala` | Modified | +1/-1 | Use Phase Index size when available |
+| `.iw/core/test/WorkflowProgressServiceTest.scala` | Modified | +49/-0 | Add 3 tests for new behavior |
+
+## Code Diff
+
+**Production change (single line):**
+
+```diff
+-      totalPhases = phases.size,
++      totalPhases = if phaseIndex.nonEmpty then phaseIndex.size else phases.size,
+```
+
+This mirrors the pattern already used in `determineCurrentPhase` (line 200-215) which also uses Phase Index as source of truth with a fallback.
+
+## Review Checklist
+
+- [ ] Fix is minimal and focused (single conditional)
+- [ ] Pattern matches existing code (see `determineCurrentPhase`)
+- [ ] Backward compatibility preserved (empty phaseIndex → old behavior)
+- [ ] Tests cover both behaviors (Phase Index + fallback)
+- [ ] No regressions in existing tests

--- a/project-management/issues/IW-100/review-phase-01-20260127-085500.md
+++ b/project-management/issues/IW-100/review-phase-01-20260127-085500.md
@@ -1,0 +1,95 @@
+# Code Review Results
+
+**Review Context:** Phase 1: Fix totalPhases to use Phase Index as source of truth for issue IW-100 (Iteration 1/3)
+**Files Reviewed:** 2 files
+**Skills Applied:** 3 (scala3, testing, architecture)
+**Timestamp:** 2026-01-27 08:55:00
+**Git Context:** git diff a1eae2c
+
+---
+
+<review skill="scala3">
+
+## Scala 3 Idioms Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+None found.
+
+### Suggestions
+
+#### Consider Using Pattern Matching for totalPhases Calculation
+**Location:** `.iw/core/dashboard/WorkflowProgressService.scala:176`
+**Problem:** The conditional expression uses verbose `if-then-else` syntax
+**Recommendation:** The current code is correct and acceptable. Pattern matching could be slightly cleaner but this is purely stylistic.
+
+</review>
+
+---
+
+<review skill="testing">
+
+## Unit Testing Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+None found.
+
+### Suggestions
+
+#### Consider Adding Edge Case Test: Phase Index Size < Phase Files Size
+**Location:** `.iw/core/test/WorkflowProgressServiceTest.scala:183-230`
+**Problem:** Tests cover phaseIndex > phases and phaseIndex == phases but not phaseIndex < phases
+**Recommendation:** Add test for when Phase Index has fewer entries than files exist
+
+#### Consider Verifying Other Progress Fields Remain Unchanged
+**Location:** `.iw/core/test/WorkflowProgressServiceTest.scala:183-230`
+**Problem:** Tests only verify `totalPhases`, not that other fields are unaffected
+**Recommendation:** Add assertions for `overallCompleted`, `overallTotal`, `phases`
+
+</review>
+
+---
+
+<review skill="architecture">
+
+## Architecture Review
+
+### Critical Issues
+
+None found.
+
+### Warnings
+
+None found.
+
+### Suggestions
+
+#### Consider Moving PhaseIndexEntry to model/
+**Location:** `.iw/core/dashboard/MarkdownTaskParser.scala:13-19`
+**Problem:** `PhaseIndexEntry` is a pure domain value object but lives in `dashboard/` package
+**Impact:** Minor organizational inconsistency per CLAUDE.md guidelines
+**Recommendation:** Consider moving to `iw.core.model` package (out of scope for this fix)
+
+</review>
+
+---
+
+## Summary
+
+- **Critical issues:** 0 (must fix before merge)
+- **Warnings:** 0 (should fix)
+- **Suggestions:** 4 (nice to have)
+
+### By Skill
+- scala3: 0 critical, 0 warnings, 1 suggestion
+- testing: 0 critical, 0 warnings, 2 suggestions
+- architecture: 0 critical, 0 warnings, 1 suggestion

--- a/project-management/issues/IW-100/review-state.json
+++ b/project-management/issues/IW-100/review-state.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "issue_id": "IW-100",
+  "status": "implementing",
+  "phase": 1,
+  "step": "implementation",
+  "branch": "IW-100-phase-01",
+  "pr_url": null,
+  "git_sha": "a1eae2c4084629f6a660e405bf35ec27b8688d54",
+  "last_updated": "2026-01-27T08:35:00Z",
+  "batch_mode": false,
+  "phase_checkpoints": {
+    "1": { "context_sha": "8a6b0409dc9d15cba0e8a8f15b754bfc2dac8979" }
+  },
+  "message": "Phase 1 implementation in progress"
+}


### PR DESCRIPTION
## Phase 1: Fix totalPhases to use Phase Index as source of truth

**Goals**: Make Phase Index the source of truth for totalPhases in dashboard, with fallback to file-based count for backward compatibility.

**Scenarios**: 3 verified
- Phase Index provides totalPhases (6-entry index, 3 files → totalPhases = 6)
- Phase Index matches file count (4-entry index, 4 files → totalPhases = 4)
- Empty Phase Index falls back to file count (empty index, 3 files → totalPhases = 3)

**Tests**: 3 unit tests added, 15 total tests pass

[Full review packet](https://github.com/iterative-works/iw-cli/blob/IW-100-phase-01/project-management/issues/IW-100/review-packet-phase-01.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)