### PR TITLE
feat(schema): Add category field to artifacts

### DIFF
--- a/.iw/core/model/ReviewStateBuilder.scala
+++ b/.iw/core/model/ReviewStateBuilder.scala
@@ -9,7 +9,7 @@ object ReviewStateBuilder:
     version: Int = 2,
     issueId: String,
     lastUpdated: String,
-    artifacts: List[(String, String)] = Nil,
+    artifacts: List[(String, String, Option[String])] = Nil,  // (label, path, category)
     status: Option[String] = None,
     display: Option[(String, Option[String], String)] = None,
     badges: List[(String, String)] = Nil,
@@ -26,8 +26,10 @@ object ReviewStateBuilder:
     val obj = ujson.Obj(
       "version" -> ujson.Num(input.version),
       "issue_id" -> ujson.Str(input.issueId),
-      "artifacts" -> ujson.Arr(input.artifacts.map { case (label, path) =>
-        ujson.Obj("label" -> ujson.Str(label), "path" -> ujson.Str(path))
+      "artifacts" -> ujson.Arr(input.artifacts.map { case (label, path, category) =>
+        val artifactObj = ujson.Obj("label" -> ujson.Str(label), "path" -> ujson.Str(path))
+        category.foreach(c => artifactObj("category") = ujson.Str(c))
+        artifactObj
       }*),
       "last_updated" -> ujson.Str(input.lastUpdated)
     )

--- a/.iw/core/model/ReviewStateValidator.scala
+++ b/.iw/core/model/ReviewStateValidator.scala
@@ -127,8 +127,14 @@ object ReviewStateValidator:
       else if !artifactObj("path").strOpt.isDefined then
         errors += ValidationError(s"artifacts[$index].path", "Field 'path' must be a string in artifact")
 
+      // Optional: category (string)
+      artifactObj.get("category").foreach { v =>
+        if !v.strOpt.isDefined then
+          errors += ValidationError(s"artifacts[$index].category", "Field 'category' must be a string in artifact")
+      }
+
       // additionalProperties: false
-      val allowedArtifactProps = Set("label", "path")
+      val allowedArtifactProps = Set("label", "path", "category")
       artifactObj.keys.foreach { key =>
         if !allowedArtifactProps.contains(key) then
           errors += ValidationError(s"artifacts[$index]", s"Unknown property '$key' in artifact")

--- a/.iw/core/test/ReviewStateValidatorTest.scala
+++ b/.iw/core/test/ReviewStateValidatorTest.scala
@@ -313,6 +313,32 @@ class ReviewStateValidatorTest extends munit.FunSuite:
     val errors = result.errors.filter(_.field.startsWith("artifacts"))
     assert(errors.nonEmpty, s"Expected error for unknown artifact property")
 
+  test("validates nested artifact structure - valid with category"):
+    val json = """{
+      "version": 1,
+      "issue_id": "IW-1",
+      "artifacts": [
+        {"label": "Analysis", "path": "analysis.md", "category": "input"},
+        {"label": "Log", "path": "log.md", "category": "output"},
+        {"label": "Tasks", "path": "tasks.md"}
+      ],
+      "last_updated": "2026-01-28T12:00:00Z"
+    }"""
+    val result = ReviewStateValidator.validate(json)
+    assert(result.isValid, s"Artifact with category should be valid: ${result.errors}")
+
+  test("validates nested artifact structure - wrong type for category"):
+    val json = """{
+      "version": 1,
+      "issue_id": "IW-1",
+      "artifacts": [{"label": "Analysis", "path": "x.md", "category": 123}],
+      "last_updated": "2026-01-28T12:00:00Z"
+    }"""
+    val result = ReviewStateValidator.validate(json)
+    assert(!result.isValid)
+    val errors = result.errors.filter(_.field.contains("category"))
+    assert(errors.nonEmpty, s"Expected error for category type: ${result.errors}")
+
   // --- Nested available_actions structure ---
 
   test("validates nested available_actions structure - valid"):

--- a/.iw/core/test/resources/review-state/valid-full.json
+++ b/.iw/core/test/resources/review-state/valid-full.json
@@ -2,18 +2,27 @@
   "version": 1,
   "issue_id": "IW-42",
   "status": "awaiting_review",
+  "display": {
+    "text": "Awaiting Review",
+    "subtext": "Phase 3 of 4",
+    "type": "warning"
+  },
+  "badges": [
+    {"label": "TDD", "type": "success"},
+    {"label": "Batch", "type": "info"}
+  ],
+  "task_lists": [
+    {"label": "Phase 3", "path": "project-management/issues/IW-42/phase-03-tasks.md"}
+  ],
+  "needs_attention": true,
   "artifacts": [
-    {"label": "Analysis", "path": "project-management/issues/IW-42/analysis.md"},
-    {"label": "Implementation Log", "path": "project-management/issues/IW-42/implementation-log.md"}
+    {"label": "Analysis", "path": "project-management/issues/IW-42/analysis.md", "category": "input"},
+    {"label": "Implementation Log", "path": "project-management/issues/IW-42/implementation-log.md", "category": "output"}
   ],
   "last_updated": "2026-01-28T17:30:00Z",
-  "phase": 3,
-  "step": "review",
-  "branch": "IW-42",
   "pr_url": "https://github.com/iterative-works/iw-cli/pull/99",
   "git_sha": "abc1234",
   "message": "Phase 3 review complete",
-  "batch_mode": true,
   "phase_checkpoints": {
     "1": {"context_sha": "7bd547909953d9414b4cd6049a411beb6258ba2b"},
     "2": {"context_sha": "d485a987e378d8193e6a211955e1709725178f00"},

--- a/.iw/test/schema.bats
+++ b/.iw/test/schema.bats
@@ -19,20 +19,20 @@ PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
     [ "$schema_ref" = "http://json-schema.org/draft-07/schema#" ]
 }
 
-@test "review-state schema requires version, issue_id, status, artifacts, last_updated" {
+@test "review-state schema requires version, issue_id, artifacts, last_updated" {
     required=$(jq -c '.required | sort' "$PROJECT_ROOT/schemas/review-state.schema.json")
-    [ "$required" = '["artifacts","issue_id","last_updated","status","version"]' ]
+    [ "$required" = '["artifacts","issue_id","last_updated","version"]' ]
 }
 
 @test "review-state schema defines all expected properties" {
     # Check required properties exist
-    run jq '[.properties | has("version", "issue_id", "status", "artifacts", "last_updated")] | all' \
+    run jq '[.properties | has("version", "issue_id", "artifacts", "last_updated")] | all' \
         "$PROJECT_ROOT/schemas/review-state.schema.json"
     [ "$status" -eq 0 ]
     [ "$output" = "true" ]
 
-    # Check optional properties exist
-    run jq '[.properties | has("phase", "step", "branch", "pr_url", "git_sha", "message", "batch_mode", "phase_checkpoints", "available_actions")] | all' \
+    # Check optional properties exist (v2 schema)
+    run jq '[.properties | has("status", "display", "badges", "task_lists", "needs_attention", "message", "pr_url", "git_sha", "phase_checkpoints", "available_actions")] | all' \
         "$PROJECT_ROOT/schemas/review-state.schema.json"
     [ "$status" -eq 0 ]
     [ "$output" = "true" ]

--- a/.iw/test/validate-review-state.bats
+++ b/.iw/test/validate-review-state.bats
@@ -21,7 +21,6 @@ PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
     run "$PROJECT_ROOT/iw" validate-review-state "$PROJECT_ROOT/.iw/core/test/resources/review-state/invalid-missing-required.json"
     [ "$status" -eq 1 ]
     [[ "$output" == *"issue_id"* ]]
-    [[ "$output" == *"status"* ]]
 }
 
 @test "invalid file with wrong types - exit 1" {
@@ -47,7 +46,7 @@ PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
     [[ "$output" == *"not found"* ]] || [[ "$output" == *"File not found"* ]]
 }
 
-@test "unknown status produces warning but exit 0" {
+@test "any status value is accepted without warning in v2 schema" {
     local tmpfile
     tmpfile="$(mktemp)"
     cat > "$tmpfile" << 'EOF'
@@ -62,8 +61,7 @@ EOF
     run "$PROJECT_ROOT/iw" validate-review-state "$tmpfile"
     rm -f "$tmpfile"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Warning"* ]]
-    [[ "$output" == *"exotic_unknown_status"* ]]
+    [[ "$output" == *"valid"* ]]
 }
 
 @test "no arguments shows usage error - exit 1" {

--- a/.iw/test/write-review-state.bats
+++ b/.iw/test/write-review-state.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# PURPOSE: E2E tests for iw write-review-state command
+# PURPOSE: E2E tests for iw write-review-state command (v2 schema)
 # PURPOSE: Tests flag-based writing, stdin mode, validation, and auto-inference
 
 # Get the project root directory (parent of .iw)
@@ -13,9 +13,8 @@ teardown() {
     rm -rf "$TEST_TMPDIR"
 }
 
-@test "write with required flags creates file and exits 0" {
+@test "write with minimal flags creates file and exits 0" {
     run "$PROJECT_ROOT/iw" write-review-state \
-        --status implementing \
         --issue-id IW-1 \
         --output "$TEST_TMPDIR/review-state.json"
     [ "$status" -eq 0 ]
@@ -23,18 +22,20 @@ teardown() {
     [[ "$output" == *"Review state written"* ]]
 }
 
-@test "write with all flags produces correct JSON" {
+@test "write with all v2 flags produces correct JSON" {
     run "$PROJECT_ROOT/iw" write-review-state \
         --status awaiting_review \
         --issue-id IW-42 \
-        --phase 3 \
-        --step review \
-        --message "Phase 3 review" \
-        --artifact "Analysis:analysis.md" \
+        --display-text "Awaiting Review" \
+        --display-subtext "Phase 3 of 4" \
+        --display-type warning \
+        --badge "TDD:success" \
+        --task-list "Phase 3:project-management/issues/IW-42/phase-03-tasks.md" \
+        --needs-attention \
+        --message "Phase 3 review complete" \
+        --artifact "Analysis:analysis.md=input" \
         --artifact "Context:phase-03-context.md" \
         --action "continue:Continue:ag-implement" \
-        --branch IW-42 \
-        --batch-mode \
         --pr-url "https://github.com/org/repo/pull/99" \
         --version 1 \
         --output "$TEST_TMPDIR/review-state.json"
@@ -44,23 +45,30 @@ teardown() {
     local json
     json="$(cat "$TEST_TMPDIR/review-state.json")"
 
-    # Check required fields
+    # Check fields
     echo "$json" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
 assert d['version'] == 1
 assert d['issue_id'] == 'IW-42'
 assert d['status'] == 'awaiting_review'
-assert d['phase'] == 3
-assert d['step'] == 'review'
-assert d['message'] == 'Phase 3 review'
+assert d['display']['text'] == 'Awaiting Review'
+assert d['display']['subtext'] == 'Phase 3 of 4'
+assert d['display']['type'] == 'warning'
+assert len(d['badges']) == 1
+assert d['badges'][0]['label'] == 'TDD'
+assert d['badges'][0]['type'] == 'success'
+assert len(d['task_lists']) == 1
+assert d['task_lists'][0]['label'] == 'Phase 3'
+assert d['needs_attention'] == True
+assert d['message'] == 'Phase 3 review complete'
 assert len(d['artifacts']) == 2
 assert d['artifacts'][0]['label'] == 'Analysis'
+assert d['artifacts'][0]['category'] == 'input'
 assert d['artifacts'][1]['label'] == 'Context'
+assert 'category' not in d['artifacts'][1]  # No category for second artifact
 assert len(d['available_actions']) == 1
 assert d['available_actions'][0]['id'] == 'continue'
-assert d['branch'] == 'IW-42'
-assert d['batch_mode'] == True
 assert d['pr_url'] == 'https://github.com/org/repo/pull/99'
 assert 'git_sha' in d
 assert 'last_updated' in d
@@ -68,7 +76,7 @@ assert 'last_updated' in d
 }
 
 @test "write with --from-stdin validates and writes" {
-    local json='{"version":1,"issue_id":"IW-1","status":"implementing","artifacts":[],"last_updated":"2026-01-28T12:00:00Z"}'
+    local json='{"version":1,"issue_id":"IW-1","artifacts":[],"last_updated":"2026-01-28T12:00:00Z"}'
     run bash -c "echo '$json' | '$PROJECT_ROOT/iw' write-review-state --from-stdin --output '$TEST_TMPDIR/review-state.json'"
     [ "$status" -eq 0 ]
     [ -f "$TEST_TMPDIR/review-state.json" ]
@@ -86,27 +94,18 @@ assert 'last_updated' in d
 @test "--output flag writes to specified path" {
     local outfile="$TEST_TMPDIR/subdir/nested/state.json"
     run "$PROJECT_ROOT/iw" write-review-state \
-        --status implementing \
         --issue-id IW-99 \
         --output "$outfile"
     [ "$status" -eq 0 ]
     [ -f "$outfile" ]
 }
 
-@test "missing --status flag exits 1" {
+@test "artifact with category is preserved in output" {
     run "$PROJECT_ROOT/iw" write-review-state \
         --issue-id IW-1 \
-        --output "$TEST_TMPDIR/review-state.json"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"--status is required"* ]]
-    [ ! -f "$TEST_TMPDIR/review-state.json" ]
-}
-
-@test "phase as string is preserved in output" {
-    run "$PROJECT_ROOT/iw" write-review-state \
-        --status implementing \
-        --issue-id IW-1 \
-        --phase "1-R1" \
+        --artifact "Analysis:analysis.md=input" \
+        --artifact "Log:implementation-log.md=output" \
+        --artifact "Tasks:tasks.md" \
         --output "$TEST_TMPDIR/review-state.json"
     [ "$status" -eq 0 ]
 
@@ -115,14 +114,16 @@ assert 'last_updated' in d
     echo "$json" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
-assert d['phase'] == '1-R1', f'Expected 1-R1 but got {d[\"phase\"]}'
+assert len(d['artifacts']) == 3
+assert d['artifacts'][0]['category'] == 'input'
+assert d['artifacts'][1]['category'] == 'output'
+assert 'category' not in d['artifacts'][2]  # No category
 "
 }
 
 @test "auto-infers issue ID from current branch" {
-    # We are on branch IW-136-phase-03, so issue ID should be IW-136
+    # We are on branch IW-136, so issue ID should be IW-136
     run "$PROJECT_ROOT/iw" write-review-state \
-        --status implementing \
         --output "$TEST_TMPDIR/review-state.json"
     [ "$status" -eq 0 ]
 
@@ -137,8 +138,9 @@ assert d['issue_id'] == 'IW-136', f'Expected IW-136 but got {d[\"issue_id\"]}'
 
 @test "written file passes validate-review-state" {
     run "$PROJECT_ROOT/iw" write-review-state \
-        --status implementing \
         --issue-id IW-1 \
+        --display-text "Implementing" \
+        --display-type progress \
         --output "$TEST_TMPDIR/review-state.json"
     [ "$status" -eq 0 ]
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -8,6 +8,15 @@ by iw-cli workflow tools and the dashboard.
 - **File:** `schemas/review-state.schema.json`
 - **Format:** JSON Schema Draft-07
 
+## Design Philosophy
+
+The schema separates **structural display concerns** from **semantic workflow concerns**:
+
+- **iw-cli (dashboard)** owns structure: "display a badge with this text and color"
+- **Workflows** own semantics: "what text to show, what color to use, when"
+
+The dashboard renders exactly what it's given - no interpretation of workflow states.
+
 ## Versioning Policy
 
 The `version` field in each `review-state.json` file tracks the schema version.
@@ -18,8 +27,6 @@ The `version` field in each `review-state.json` file tracks the schema version.
   - Changing the type of an existing field
   - Renaming a field
 - **Adding optional fields** does NOT require a version bump.
-- **Adding new known status values** does NOT require a version bump (status
-  is an open enum).
 
 ## Field Summary
 
@@ -29,20 +36,81 @@ The `version` field in each `review-state.json` file tracks the schema version.
 |----------------|---------|----------------------------------------------|
 | `version`      | integer | Schema version (minimum 1)                   |
 | `issue_id`     | string  | Issue tracker identifier (e.g., "IW-136")    |
-| `status`       | string  | Current workflow status (open enum)           |
-| `artifacts`    | array   | Workflow artifacts (may be empty)             |
+| `artifacts`    | array   | Workflow artifacts (may be empty)            |
 | `last_updated` | string  | ISO 8601 date-time of last modification      |
 
 ### Optional Fields
 
-| Field               | Type             | Description                              |
-|---------------------|------------------|------------------------------------------|
-| `phase`             | integer / string | Current phase number or label            |
-| `step`              | string           | Current step within the phase            |
-| `branch`            | string           | Git branch name                          |
-| `pr_url`            | string / null    | Pull request URL, or null                |
-| `git_sha`           | string           | Latest relevant commit SHA               |
-| `message`           | string           | Human-readable state description         |
-| `batch_mode`        | boolean          | Whether batch mode is active             |
-| `phase_checkpoints` | object           | Map of phase numbers to checkpoint data  |
-| `available_actions` | array            | Actions the user can take from this state|
+| Field               | Type             | Description                                        |
+|---------------------|------------------|----------------------------------------------------|
+| `status`            | string           | Machine-readable workflow state (for workflow use) |
+| `display`           | object           | Presentation instructions for status badge         |
+| `badges`            | array            | Additional contextual indicators                   |
+| `task_lists`        | array            | Files containing task checkboxes for progress      |
+| `needs_attention`   | boolean          | Flag for attention-grabbing visual indicator       |
+| `message`           | string           | Prominent notification for the user                |
+| `pr_url`            | string / null    | Pull request URL                                   |
+| `git_sha`           | string           | Latest relevant commit SHA                         |
+| `phase_checkpoints` | object           | Map of phase numbers to checkpoint data            |
+| `available_actions` | array            | Actions the user can take from dashboard           |
+
+### Display Object
+
+Controls how the status badge is rendered:
+
+| Field     | Type   | Required | Description                                           |
+|-----------|--------|----------|-------------------------------------------------------|
+| `text`    | string | Yes      | Primary label shown in the badge                      |
+| `subtext` | string | No       | Secondary information shown beneath                   |
+| `type`    | enum   | Yes      | Display category: info, success, warning, error, progress |
+
+### Badge Object
+
+Additional contextual indicators:
+
+| Field   | Type   | Required | Description                                           |
+|---------|--------|----------|-------------------------------------------------------|
+| `label` | string | Yes      | Short text shown on the badge                         |
+| `type`  | enum   | Yes      | Color category: info, success, warning, error, progress |
+
+### Artifact Object
+
+Workflow artifacts for user review:
+
+| Field      | Type   | Required | Description                                        |
+|------------|--------|----------|----------------------------------------------------|
+| `label`    | string | Yes      | Human-readable name (e.g., "Analysis")             |
+| `path`     | string | Yes      | Path relative to project root                      |
+| `category` | string | No       | Optional grouping category (e.g., "input", "output") |
+
+**Category conventions:**
+- `input` - Planning artifacts (analysis, context, tasks)
+- `output` - Execution results (log, reviews, verification)
+- Workflows may define additional categories as needed
+
+### Task List Object
+
+References to markdown files with task checkboxes:
+
+| Field   | Type   | Required | Description                              |
+|---------|--------|----------|------------------------------------------|
+| `label` | string | Yes      | Human-readable name (e.g., "Phase 2")    |
+| `path`  | string | Yes      | Path to markdown file with checkboxes    |
+
+### Action Object
+
+Actions available from the dashboard:
+
+| Field   | Type   | Required | Description                              |
+|---------|--------|----------|------------------------------------------|
+| `id`    | string | Yes      | Machine-readable identifier              |
+| `label` | string | Yes      | Human-readable button label              |
+| `skill` | string | Yes      | Skill to invoke when triggered           |
+
+### Phase Checkpoint Object
+
+Recovery data for revert-to-phase functionality:
+
+| Field         | Type   | Required | Description                              |
+|---------------|--------|----------|------------------------------------------|
+| `context_sha` | string | Yes      | Git blob SHA of phase context file       |

--- a/schemas/review-state.schema.json
+++ b/schemas/review-state.schema.json
@@ -54,8 +54,8 @@
       },
       "examples": [
         [
-          {"label": "Analysis", "path": "project-management/issues/IW-136/analysis.md"},
-          {"label": "Implementation Log", "path": "project-management/issues/IW-136/implementation-log.md"}
+          {"label": "Analysis", "path": "project-management/issues/IW-136/analysis.md", "category": "input"},
+          {"label": "Implementation Log", "path": "project-management/issues/IW-136/implementation-log.md", "category": "output"}
         ]
       ]
     },
@@ -170,6 +170,10 @@
         "path": {
           "type": "string",
           "description": "Path to the artifact file, relative to the project root."
+        },
+        "category": {
+          "type": "string",
+          "description": "Optional categorization for grouping artifacts in the dashboard. Workflows decide the categories; common values include 'input' (planning documents) and 'output' (execution results)."
         }
       }
     },


### PR DESCRIPTION
## Summary

- Add optional `category` field to artifact objects in review-state.json schema
- Enables grouping artifacts by type (e.g., `input` for planning docs, `output` for execution results)
- Update E2E tests to match v2 schema structure

## Changes

- **Schema**: Add `category` property to artifact definition
- **Validator**: Allow category field in artifact objects  
- **Builder**: Support artifact category in BuildInput
- **Command**: Accept category via `--artifact "label:path=category"` format
- **README**: Update to document v2 schema and category conventions

## Test plan

- [x] Unit tests pass (validator, builder)
- [x] E2E tests pass (schema, validate-review-state, write-review-state)
- [x] New test for artifact category preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)