### PR TITLE
fix(ci): Fix test 6 timeout in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,4 @@ jobs:
           sudo /tmp/bats-core/install.sh /usr/local
       - name: Run all tests
         run: ./iw test
+        timeout-minutes: 15

--- a/.iw/test/test-cmd.bats
+++ b/.iw/test/test-cmd.bats
@@ -128,6 +128,10 @@ EOF
 }
 EOF
 
+    # Remove all commands except test.scala so the compile check is fast —
+    # this test only verifies that unit and E2E tests both run together.
+    find .iw/commands -name '*.scala' ! -name 'test.scala' -delete
+
     run_with_clean_path ./iw test
     [ "$status" -eq 0 ]
     [[ "$output" == *"unit test passes"* ]] || [[ "$output" == *"UnitTest"* ]]


### PR DESCRIPTION
## Summary

- Remove all commands except `test.scala` in test 6 (test-cmd.bats) before running `./iw test` — the test only asserts on unit and E2E output, but was compiling all 25 commands individually on CI, taking 8+ minutes and intermittently timing out
- Add 15-minute step timeout to CI test job to prevent excessive hangs

## Test plan

- [x] All 6 tests in test-cmd.bats pass locally
- [x] Full test suite (`./iw test`) passes locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)