### PR TITLE
docs: Update README and llms.txt with IW-222 features

### DIFF
--- a/.iw/llms.txt
+++ b/.iw/llms.txt
@@ -25,6 +25,11 @@ Pure domain types with no I/O. Safe to use anywhere.
 - [GitStatus](docs/GitStatus.md): Git repository status (branch, clean/dirty)
 - [WorkflowTypes](docs/WorkflowTypes.md): ReviewState, PhaseInfo, WorkflowProgress, PullRequestData
 - [ServerTypes](docs/ServerTypes.md): ServerConfig, ServerStatus, ServerState, CacheConfig, DeletionSafety
+- [ProjectPath](docs/ProjectPath.md): Pure derivation of main project path from worktree path
+- [ProjectSummary](docs/ProjectSummary.md): Project metadata for listing (name, path, tracker, worktree count)
+- [WorktreeSummary](docs/WorktreeSummary.md): Worktree summary for listing (issue, PR, review state)
+- [WorktreeStatus](docs/WorktreeStatus.md): Detailed worktree status (git, issue, PR, review, progress)
+- [ServerStateCodec](docs/ServerStateCodec.md): Shared JSON serialization for server state types
 
 ## Adapters (I/O Operations)
 
@@ -37,7 +42,11 @@ Adapters for shell commands, file I/O, and external APIs.
 - [ConfigRepository](docs/ConfigRepository.md): Configuration file read/write
 - [Log](docs/Log.md): Logging with debug/info/warn/error levels
 - [Prompt](docs/Prompt.md): Interactive console input (ask, confirm)
-- [Tmux](docs/Tmux.md): Tmux session management
+- [Tmux](docs/Tmux.md): Tmux session management (sessions, sendKeys)
+- [StateReader](docs/StateReader.md): Read server state.json for worktree/cache data
+- [ServerClient](docs/ServerClient.md): HTTP client for dashboard server API
+- [ServerConfigRepository](docs/ServerConfigRepository.md): Read/write server config.json
+- [ProcessManager](docs/ProcessManager.md): Manage dashboard server process lifecycle
 - [GitHubClient](docs/GitHubClient.md): GitHub API via gh CLI
 - [LinearClient](docs/LinearClient.md): Linear API via GraphQL
 - [GitLabClient](docs/GitLabClient.md): GitLab API via glab CLI
@@ -51,6 +60,9 @@ Console output and formatting utilities.
 - [IssueFormatter](docs/IssueFormatter.md): Format Issue for CLI display
 - [MarkdownRenderer](docs/MarkdownRenderer.md): Convert Markdown to HTML
 - [TimestampFormatter](docs/TimestampFormatter.md): Format timestamps as relative time
+- [ProjectsFormatter](docs/ProjectsFormatter.md): Format project list for CLI display
+- [WorktreesFormatter](docs/WorktreesFormatter.md): Format worktree list for CLI display
+- [StatusFormatter](docs/StatusFormatter.md): Format detailed worktree status for CLI display
 
 ## Architecture Notes
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,42 @@ If not specified, defaults to "latest".
 
 | Command | Description |
 |---------|-------------|
-| `iw init` | Interactive setup, creates `.iw/config.yaml` |
+| `iw init` | Interactive setup, creates `.iw/config.conf` |
 | `iw doctor` | Validate environment (tokens, tmux, etc.) |
-| `iw start <issue-id>` | Create sibling worktree + tmux session |
-| `iw open [issue-id]` | Open tmux session (defaults to current branch) |
+| `iw start [--prompt <text>] <issue-id>` | Create sibling worktree + tmux session |
+| `iw open [--prompt <text>] [issue-id]` | Open tmux session (defaults to current branch) |
 | `iw rm <issue-id>` | Kill session, remove worktree, delete branch |
-| `iw issue` | Fetch issue details from configured tracker |
+| `iw issue [issue-id]` | Fetch issue details from configured tracker |
+| `iw projects [--json]` | List all registered projects |
+| `iw worktrees [--all] [--json]` | List worktrees for current project |
+| `iw status [issue-id] [--json]` | Show detailed worktree status |
 | `iw review-state` | Manage review-state.json files (validate, write, update) |
+| `iw test [unit\|compile\|e2e]` | Run tests |
+
+### Agent integration
+
+The `--prompt` flag on `start` and `open` enables agent-driven development. When provided, `iw` launches a Claude Code session in the tmux pane with the given prompt and exits immediately (detached mode).
+
+```bash
+# Start work on an issue with an agent
+iw start 203 --prompt "Analyze this issue and create analysis.md"
+
+# Send new instructions to an existing session
+iw open 203 --prompt "Continue with implementation phase 2"
+```
+
+The `projects`, `worktrees`, and `status` commands support `--json` for machine-readable output, enabling agents to discover and monitor worktrees programmatically.
+
+```bash
+# List all projects
+iw projects --json
+
+# List worktrees for current project
+iw worktrees --json
+
+# Get detailed status for a worktree
+iw status IW-203 --json
+```
 
 For detailed documentation on `review-state` commands, see [docs/commands/review-state.md](docs/commands/review-state.md).
 


### PR DESCRIPTION
## Summary
- Updated README.md commands table with new commands (`projects`, `worktrees`, `status`, `test`)
- Added `--prompt` flag documentation for `start` and `open` commands
- Added agent integration section with usage examples
- Updated `.iw/llms.txt` with new model types, adapters, and output formatters from IW-222

## Test plan
- [x] Pre-commit hooks pass (format + compile)
- [x] Pre-push hooks pass (unit tests + command compilation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)