### PR TITLE
fix: Fix register command team derivation and error handling

### DIFF
--- a/.iw/commands/register.scala
+++ b/.iw/commands/register.scala
@@ -33,15 +33,14 @@ import iw.core.output.*
         config.projectName,
         currentDir.toString,
         config.trackerType.toString,
-        config.team,
+        config.teamIdentifier,
         trackerUrl
       ) match
         case Left(error) =>
-          Output.warning(s"Failed to register project with dashboard: $error")
+          Output.error(s"Failed to register project with dashboard: $error")
+          sys.exit(1)
         case Right(_) =>
-          () // Silent success for dashboard call
-
-      Output.success(s"Registered project '${config.projectName}' at ${currentDir}")
+          Output.success(s"Registered project '${config.projectName}' at ${currentDir}")
 
     case Right(issueId) =>
       // Issue worktree — register the worktree
@@ -52,31 +51,30 @@ import iw.core.output.*
         issueId.team
       ) match
         case Left(error) =>
-          Output.warning(s"Failed to register worktree with dashboard: $error")
+          Output.error(s"Failed to register worktree with dashboard: $error")
+          sys.exit(1)
         case Right(_) =>
-          () // Silent success for dashboard call
-
-      // Also register the parent project (best-effort)
-      ProjectPath.deriveMainProjectPath(currentDir.toString) match
-        case None =>
-          Output.warning("Could not derive parent project path from current directory")
-        case Some(parentPath) =>
-          val parentConfigPath = os.Path(parentPath) / Constants.Paths.IwDir / "config.conf"
-          ConfigFileRepository.read(parentConfigPath) match
+          // Also register the parent project (best-effort)
+          ProjectPath.deriveMainProjectPath(currentDir.toString) match
             case None =>
-              Output.warning(s"Could not read parent project config at $parentConfigPath, skipping project registration")
-            case Some(parentConfig) =>
-              val trackerUrl = TrackerUrlBuilder.buildTrackerUrl(parentConfig)
-              ServerClient.registerProject(
-                parentConfig.projectName,
-                parentPath,
-                parentConfig.trackerType.toString,
-                parentConfig.team,
-                trackerUrl
-              ) match
-                case Left(error) =>
-                  Output.warning(s"Failed to register parent project with dashboard: $error")
-                case Right(_) =>
-                  () // Silent success for dashboard call
+              Output.warning("Could not derive parent project path from current directory")
+            case Some(parentPath) =>
+              val parentConfigPath = os.Path(parentPath) / Constants.Paths.IwDir / "config.conf"
+              ConfigFileRepository.read(parentConfigPath) match
+                case None =>
+                  Output.warning(s"Could not read parent project config at $parentConfigPath, skipping project registration")
+                case Some(parentConfig) =>
+                  val trackerUrl = TrackerUrlBuilder.buildTrackerUrl(parentConfig)
+                  ServerClient.registerProject(
+                    parentConfig.projectName,
+                    parentPath,
+                    parentConfig.trackerType.toString,
+                    parentConfig.teamIdentifier,
+                    trackerUrl
+                  ) match
+                    case Left(error) =>
+                      Output.warning(s"Failed to register parent project with dashboard: $error")
+                    case Right(_) =>
+                      () // Silent success for parent project dashboard call
 
-      Output.success(s"Registered worktree for ${issueId.value} at ${currentDir}")
+          Output.success(s"Registered worktree for ${issueId.value} at ${currentDir}")

--- a/.iw/core/dashboard/application/MainProjectService.scala
+++ b/.iw/core/dashboard/application/MainProjectService.scala
@@ -66,11 +66,7 @@ object MainProjectService:
 
             // Create MainProject with metadata from config
             val trackerTypeStr = config.trackerType.toString.toLowerCase
-            val team = config.trackerType match
-              case iw.core.model.IssueTrackerType.GitHub =>
-                config.repository.getOrElse(config.team)
-              case _ =>
-                config.team
+            val team = config.teamIdentifier
 
             // Build tracker URL based on tracker type
             val trackerUrl = TrackerUrlBuilder.buildTrackerUrl(config)

--- a/.iw/core/model/Config.scala
+++ b/.iw/core/model/Config.scala
@@ -130,6 +130,16 @@ case class ProjectConfiguration(
   def teamPrefix: Option[String] = tracker.teamPrefix
   def youtrackBaseUrl: Option[String] = tracker.baseUrl
 
+  /** Team identifier for server registration.
+    * GitHub and GitLab use the repository (owner/repo) as the team identifier.
+    * Linear and YouTrack use the team key directly.
+    */
+  def teamIdentifier: String = trackerType match
+    case IssueTrackerType.GitHub | IssueTrackerType.GitLab =>
+      repository.getOrElse(team)
+    case _ =>
+      team
+
 object ProjectConfiguration:
   // Factory method for flat parameter style (used by tests and legacy code)
   def create(

--- a/.iw/core/test/ConfigTest.scala
+++ b/.iw/core/test/ConfigTest.scala
@@ -731,3 +731,50 @@ class ConfigTest extends munit.FunSuite:
     assert(result.isRight)
     val roundTripped = result.getOrElse(fail("Expected Right"))
     assertEquals(roundTripped.repository, original.repository)
+
+  // ========== teamIdentifier Tests ==========
+
+  test("teamIdentifier returns repository for GitHub config"):
+    val config = ProjectConfiguration.create(
+      trackerType = IssueTrackerType.GitHub,
+      team = "",
+      repository = Some("iterative-works/iw-cli"),
+      projectName = "test",
+      teamPrefix = Some("IW")
+    )
+    assertEquals(config.teamIdentifier, "iterative-works/iw-cli")
+
+  test("teamIdentifier falls back to team for GitHub config without repository"):
+    val config = ProjectConfiguration.create(
+      trackerType = IssueTrackerType.GitHub,
+      team = "fallback-team",
+      projectName = "test",
+      teamPrefix = Some("IW")
+    )
+    assertEquals(config.teamIdentifier, "fallback-team")
+
+  test("teamIdentifier returns repository for GitLab config"):
+    val config = ProjectConfiguration.create(
+      trackerType = IssueTrackerType.GitLab,
+      team = "",
+      repository = Some("group/subgroup/project"),
+      projectName = "test",
+      teamPrefix = Some("PROJ")
+    )
+    assertEquals(config.teamIdentifier, "group/subgroup/project")
+
+  test("teamIdentifier returns team for Linear config"):
+    val config = ProjectConfiguration.create(
+      trackerType = IssueTrackerType.Linear,
+      team = "IWLE",
+      projectName = "test"
+    )
+    assertEquals(config.teamIdentifier, "IWLE")
+
+  test("teamIdentifier returns team for YouTrack config"):
+    val config = ProjectConfiguration.create(
+      trackerType = IssueTrackerType.YouTrack,
+      team = "TEST",
+      projectName = "test"
+    )
+    assertEquals(config.teamIdentifier, "TEST")

--- a/.iw/test/register.bats
+++ b/.iw/test/register.bats
@@ -115,3 +115,48 @@ teardown() {
     [[ "$output" == *"Registered worktree"* ]]
     [[ "$output" == *"IWLE-999"* ]]
 }
+
+@test "register succeeds with GitHub config (repository instead of team)" {
+    # Replace config with a GitHub-style config (no team key)
+    cat > .iw/config.conf << 'EOF'
+project {
+  name = testproject
+}
+
+tracker {
+  type = github
+  repository = "owner/repo"
+  teamPrefix = "TR"
+}
+EOF
+    # On a non-issue branch, register should register the project
+    git checkout -b feature-xyz
+
+    run "$PROJECT_ROOT/iw" register
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Registered project"* ]]
+    [[ "$output" == *"testproject"* ]]
+}
+
+@test "register succeeds with GitLab config (repository instead of team)" {
+    # Replace config with a GitLab-style config (no team key)
+    cat > .iw/config.conf << 'EOF'
+project {
+  name = testproject
+}
+
+tracker {
+  type = gitlab
+  repository = "group/project"
+  teamPrefix = "GL"
+}
+EOF
+    git checkout -b feature-xyz
+
+    run "$PROJECT_ROOT/iw" register
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Registered project"* ]]
+    [[ "$output" == *"testproject"* ]]
+}


### PR DESCRIPTION
## Summary

- **Bug 1**: `iw register` passed empty `team` for GitHub/GitLab projects (which use `repository` instead), causing "Team cannot be empty" server rejection. Added `teamIdentifier` method on `ProjectConfiguration` that resolves to `repository` for GitHub/GitLab and `team` for Linear/YouTrack. Also fixed the same logic in `MainProjectService` which missed GitLab.
- **Bug 2**: Success message printed unconditionally even when registration failed. Now only prints on `Right`; `Left` exits with non-zero status.

## Test plan

- [x] 5 unit tests for `teamIdentifier` (GitHub, GitHub fallback, GitLab, Linear, YouTrack)
- [x] 2 new E2E tests: register with GitHub config, register with GitLab config
- [x] All existing unit tests pass
- [x] All existing E2E register tests pass
- [x] Core compiles with `-Werror`
- [x] All 28 commands compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)