### PR TITLE
fix: Prevent --describe from exiting 1 on missing headers

### DIFF
--- a/iw-run
+++ b/iw-run
@@ -44,10 +44,10 @@ parse_command_header() {
 
     case "$field" in
         PURPOSE)
-            grep "^// PURPOSE:" "$file" | head -1 | sed 's|^// PURPOSE: *||'
+            grep "^// PURPOSE:" "$file" | head -1 | sed 's|^// PURPOSE: *||' || true
             ;;
         USAGE)
-            grep "^// USAGE:" "$file" | head -1 | sed 's|^// USAGE: *||'
+            grep "^// USAGE:" "$file" | head -1 | sed 's|^// USAGE: *||' || true
             ;;
         ARGS)
             grep "^// ARGS:" "$file" -A 100 | tail -n +2 | grep "^//   " | sed 's|^//   *||' | grep -v "^EXAMPLE:" || true


### PR DESCRIPTION
## Summary

- `./iw --describe phase-commit` (and other commands without `// USAGE:` headers) exited with code 1 despite printing correct output
- Root cause: `grep` returns exit 1 on no match, combined with `set -euo pipefail`
- Added `|| true` to PURPOSE and USAGE grep calls, matching the existing pattern used by ARGS and EXAMPLES

🤖 Generated with [Claude Code](https://claude.com/claude-code)