### PR TITLE
docs: Add USAGE headers to phase lifecycle commands

### DIFF
--- a/.iw/commands/phase-advance.scala
+++ b/.iw/commands/phase-advance.scala
@@ -1,5 +1,5 @@
 // PURPOSE: Verifies a phase PR is merged then advances the feature branch to match remote
-// PURPOSE: Usage: iw phase-advance [--issue-id ID] [--phase-number N]
+// USAGE: iw phase-advance [--issue-id ID] [--phase-number N]
 
 import iw.core.model.*
 import iw.core.adapters.*

--- a/.iw/commands/phase-commit.scala
+++ b/.iw/commands/phase-commit.scala
@@ -1,5 +1,5 @@
 // PURPOSE: Stages all changes, commits with a structured message, and updates phase task file
-// PURPOSE: Usage: iw phase-commit --title TITLE [--items ITEM1,ITEM2,...] [--issue-id ID] [--phase-number N]
+// USAGE: iw phase-commit --title TITLE [--items ITEM1,ITEM2,...] [--issue-id ID] [--phase-number N]
 
 import iw.core.model.*
 import iw.core.adapters.*

--- a/.iw/commands/phase-pr.scala
+++ b/.iw/commands/phase-pr.scala
@@ -1,5 +1,5 @@
 // PURPOSE: Pushes the phase sub-branch and creates a GitHub/GitLab PR or MR
-// PURPOSE: Usage: iw phase-pr --title TITLE [--body BODY] [--batch] [--issue-id ID] [--phase-number N]
+// USAGE: iw phase-pr --title TITLE [--body BODY] [--batch] [--issue-id ID] [--phase-number N]
 
 import iw.core.model.*
 import iw.core.adapters.*

--- a/.iw/commands/phase-start.scala
+++ b/.iw/commands/phase-start.scala
@@ -1,5 +1,5 @@
 // PURPOSE: Creates a phase sub-branch from a feature branch and records baseline SHA
-// PURPOSE: Usage: iw phase-start <phase-number> [--issue-id ID]
+// USAGE: iw phase-start <phase-number> [--issue-id ID]
 
 import iw.core.model.*
 import iw.core.adapters.*


### PR DESCRIPTION
## Summary

- Changed second `// PURPOSE:` line to `// USAGE:` in all four phase commands
- `./iw --describe phase-*` now shows usage information

🤖 Generated with [Claude Code](https://claude.com/claude-code)