### PR TITLE
Add iw update command

### DIFF
--- a/.iw/scripts/package-release.sh
+++ b/.iw/scripts/package-release.sh
@@ -18,8 +18,9 @@ RELEASE_PACKAGE_DIR="$RELEASE_DIR/iw-cli-$VERSION"
 rm -rf "$RELEASE_PACKAGE_DIR"
 mkdir -p "$RELEASE_PACKAGE_DIR"/{commands,core,scripts}
 
-# Copy iw-run launcher
+# Copy iw-run launcher and bootstrap script
 cp "$PROJECT_ROOT/iw-run" "$RELEASE_PACKAGE_DIR/"
+cp "$PROJECT_ROOT/iw-bootstrap" "$RELEASE_PACKAGE_DIR/"
 
 # Copy all command files
 cp "$PROJECT_ROOT/.iw/commands"/*.scala "$RELEASE_PACKAGE_DIR/commands/"

--- a/iw-bootstrap
+++ b/iw-bootstrap
@@ -54,6 +54,28 @@ download_release() {
     echo "Downloaded and extracted to $version_dir" >&2
 }
 
+# Re-download and re-bootstrap the current version
+update_release() {
+    local version=$(read_version)
+    local version_dir="$CACHE_DIR/$version"
+
+    echo "Updating iw-cli (version: $version)..." >&2
+
+    # Remove cached version to force re-download
+    if [ -d "$version_dir" ]; then
+        rm -rf "$version_dir"
+    fi
+
+    download_release "$version"
+
+    # Re-bootstrap
+    local iw_run="$version_dir/iw-run"
+    IW_PROJECT_DIR="$SCRIPT_DIR" "$iw_run" --bootstrap
+
+    # Show new version
+    IW_PROJECT_DIR="$SCRIPT_DIR" "$iw_run" version
+}
+
 # Main execution
 main() {
     # IW_HOME override for local development
@@ -73,6 +95,12 @@ main() {
             core_dir="$IW_HOME/core"
         fi
         IW_PROJECT_DIR="$SCRIPT_DIR" IW_COMMANDS_DIR="$commands_dir" IW_CORE_DIR="$core_dir" exec "$iw_run" "$@"
+    fi
+
+    # Handle update command before delegation
+    if [ "${1:-}" = "update" ]; then
+        update_release
+        exit 0
     fi
 
     local version=$(read_version)


### PR DESCRIPTION
## Summary
- Add `iw update` to the bootstrap script — clears cached version and re-downloads
- Include `iw-bootstrap` in release tarballs for easier project setup

## How it works
The bootstrap script caches releases at `~/.local/share/iw/versions/<version>/` and never re-checks. `iw update` deletes the cached dir, re-downloads from GitHub releases, and re-bootstraps.

## Usage on consumer machine
1. Copy the updated `iw` (bootstrap) script into the project
2. Run `./iw update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)