### PR TITLE
Fix phase-pr for YouTrack+GitLab projects

### DIFF
--- a/.iw/commands/phase-pr.scala
+++ b/.iw/commands/phase-pr.scala
@@ -45,7 +45,7 @@ import iw.core.output.*
   val forgeType = ForgeType.resolve(remoteOpt, config.trackerType)
 
   val repository = config.repository.getOrElse {
-    remoteOpt.flatMap(r => r.repositoryOwnerAndName.toOption).getOrElse {
+    remoteOpt.flatMap(r => r.extractRepositoryPath.toOption).getOrElse {
       Output.error("Cannot determine repository. Set 'tracker.repository' in .iw/config.conf")
       sys.exit(1)
     }

--- a/.iw/core/model/Config.scala
+++ b/.iw/core/model/Config.scala
@@ -102,6 +102,9 @@ case class GitRemote(url: String):
         else
           Right(path)
 
+  def extractRepositoryPath: Either[String, String] =
+    repositoryOwnerAndName.orElse(extractGitLabRepository)
+
 enum IssueTrackerType:
   case Linear, YouTrack, GitHub, GitLab
 
@@ -194,20 +197,14 @@ object ConfigSerializer:
       case IssueTrackerType.GitLab => Constants.TrackerTypeValues.GitLab
 
     val versionLine = config.version.map(v => s"\nversion = $v").getOrElse("")
-    val baseUrlLine = config.youtrackBaseUrl.map(url => s"""\n  baseUrl = "$url"""").getOrElse("")
 
-    // For GitHub and GitLab, use repository and teamPrefix instead of team
-    val trackerDetails = config.trackerType match
-      case IssueTrackerType.GitHub =>
-        val repoLine = config.repository.map(repo => s"""repository = "$repo"""").getOrElse("")
-        val prefixLine = config.teamPrefix.map(p => s"""\n  teamPrefix = "$p"""").getOrElse("")
-        s"$repoLine$prefixLine"
-      case IssueTrackerType.GitLab =>
-        val repoLine = config.repository.map(repo => s"""repository = "$repo"""").getOrElse("")
-        val prefixLine = config.teamPrefix.map(p => s"""\n  teamPrefix = "$p"""").getOrElse("")
-        s"$repoLine$prefixLine$baseUrlLine"
-      case _ =>
-        s"team = ${config.team}$baseUrlLine"
+    val trackerFields = Seq(
+      config.repository.map(repo => s"""repository = "$repo""""),
+      if config.team.nonEmpty then Some(s"team = ${config.team}") else None,
+      config.teamPrefix.map(p => s"""teamPrefix = "$p""""),
+      config.youtrackBaseUrl.map(url => s"""baseUrl = "$url"""")
+    ).flatten
+    val trackerDetails = trackerFields.mkString("\n  ")
 
     s"""tracker {
        |  type = $trackerTypeStr
@@ -232,50 +229,48 @@ object ConfigSerializer:
         case other => Left(s"Unknown tracker type: $other")
 
       trackerTypeEither.flatMap { trackerType =>
-        // For GitHub and GitLab, read repository and teamPrefix; for others, read team
-        val trackerDetailsEither: Either[String, (String, Option[String], Option[String])] = trackerType match
-          case IssueTrackerType.GitHub | IssueTrackerType.GitLab =>
-            val trackerName = if trackerType == IssueTrackerType.GitHub then "GitHub" else "GitLab"
-            if !config.hasPath(Constants.ConfigKeys.TrackerRepository) then
-              Left(s"repository required for $trackerName tracker")
+        // Read all fields optionally — commands that need them fail at use-time
+        val team = if config.hasPath(Constants.ConfigKeys.TrackerTeam) then
+          config.getString(Constants.ConfigKeys.TrackerTeam)
+        else ""
+
+        val repositoryEither: Either[String, Option[String]] =
+          if config.hasPath(Constants.ConfigKeys.TrackerRepository) then
+            val repo = config.getString(Constants.ConfigKeys.TrackerRepository)
+            if !repo.contains('/') || repo.split('/').exists(_.isEmpty) then
+              Left("repository must be in owner/repo format")
             else
-              val repo = config.getString(Constants.ConfigKeys.TrackerRepository)
-              // Validate repository format: owner/repo or owner/group/repo for GitLab
-              if !repo.contains('/') || repo.split('/').exists(_.isEmpty) then
-                Left("repository must be in owner/repo format")
-              // Require and validate teamPrefix for GitHub and GitLab
-              else if !config.hasPath(Constants.ConfigKeys.TrackerTeamPrefix) then
-                Left(s"teamPrefix required for $trackerName tracker")
-              else
-                val prefix = config.getString(Constants.ConfigKeys.TrackerTeamPrefix)
-                TeamPrefixValidator.validate(prefix).map(validPrefix =>
-                  ("", Some(repo), Some(validPrefix))
-                )
-          case _ =>
-            val t = config.getString(Constants.ConfigKeys.TrackerTeam)
-            Right((t, None, None))
-
-        trackerDetailsEither.map { case (team, repository, teamPrefix) =>
-          val projectName = config.getString(Constants.ConfigKeys.ProjectName)
-
-          // Read version, default to "latest" if not present
-          val version = if config.hasPath(Constants.ConfigKeys.Version) then
-            Some(config.getString(Constants.ConfigKeys.Version))
+              Right(Some(repo))
           else
-            Some("latest")
+            Right(None)
 
-          // Read YouTrack base URL if present
-          val youtrackBaseUrl = if config.hasPath(Constants.ConfigKeys.TrackerBaseUrl) then
-            Some(config.getString(Constants.ConfigKeys.TrackerBaseUrl))
+        val teamPrefixEither: Either[String, Option[String]] =
+          if config.hasPath(Constants.ConfigKeys.TrackerTeamPrefix) then
+            val prefix = config.getString(Constants.ConfigKeys.TrackerTeamPrefix)
+            TeamPrefixValidator.validate(prefix).map(Some(_))
           else
-            None
+            Right(None)
 
-          ProjectConfiguration(
-            tracker = TrackerConfig(trackerType, team, repository, teamPrefix, youtrackBaseUrl),
-            project = ProjectConfig(projectName),
-            version = version
-          )
-        }
+        val projectName = config.getString(Constants.ConfigKeys.ProjectName)
+
+        val version = if config.hasPath(Constants.ConfigKeys.Version) then
+          Some(config.getString(Constants.ConfigKeys.Version))
+        else
+          Some("latest")
+
+        val youtrackBaseUrl = if config.hasPath(Constants.ConfigKeys.TrackerBaseUrl) then
+          Some(config.getString(Constants.ConfigKeys.TrackerBaseUrl))
+        else
+          None
+
+        for
+          repository <- repositoryEither
+          teamPrefix <- teamPrefixEither
+        yield ProjectConfiguration(
+          tracker = TrackerConfig(trackerType, team, repository, teamPrefix, youtrackBaseUrl),
+          project = ProjectConfig(projectName),
+          version = version
+        )
       }
     catch
       case e: Exception => Left(s"Failed to parse config: ${e.getMessage}")

--- a/.iw/core/test/ConfigFileTest.scala
+++ b/.iw/core/test/ConfigFileTest.scala
@@ -135,7 +135,7 @@ class ConfigFileTest extends munit.FunSuite, Fixtures:
     val Left(errorMsg) = result: @unchecked
     assert(errorMsg.contains("Failed to parse config"))
 
-  test("ConfigSerializer returns Left with meaningful message for missing tracker team"):
+  test("ConfigSerializer succeeds with empty team when tracker team is missing"):
     val hocon = """
       tracker {
         type = linear
@@ -147,9 +147,9 @@ class ConfigFileTest extends munit.FunSuite, Fixtures:
     """
 
     val result = ConfigSerializer.fromHocon(hocon)
-    assert(result.isLeft)
-    val Left(errorMsg) = result: @unchecked
-    assert(errorMsg.contains("Failed to parse config"))
+    assert(result.isRight)
+    val config = result.getOrElse(fail("Expected Right"))
+    assertEquals(config.team, "")
 
   test("ConfigSerializer returns Left with meaningful message for missing project name"):
     val hocon = """

--- a/.iw/core/test/ConfigTest.scala
+++ b/.iw/core/test/ConfigTest.scala
@@ -140,7 +140,7 @@ class ConfigTest extends munit.FunSuite:
     assertEquals(roundTripped.teamPrefix, original.teamPrefix)
     assertEquals(roundTripped.projectName, original.projectName)
 
-  test("ConfigSerializer fails when GitHub config missing repository"):
+  test("ConfigSerializer succeeds when GitHub config missing repository"):
     val hocon = """
       tracker {
         type = github
@@ -150,8 +150,11 @@ class ConfigTest extends munit.FunSuite:
       }
     """
     val result = ConfigSerializer.fromHocon(hocon)
-    assert(result.isLeft)
-    assert(result.left.getOrElse("").contains("repository required for GitHub tracker"))
+    assert(result.isRight)
+    val config = result.getOrElse(fail("Expected Right"))
+    assertEquals(config.trackerType, IssueTrackerType.GitHub)
+    assertEquals(config.repository, None)
+    assertEquals(config.teamPrefix, None)
 
   test("ConfigSerializer fails when GitHub repository has invalid format"):
     val hocon = """
@@ -271,7 +274,7 @@ class ConfigTest extends munit.FunSuite:
     assertEquals(config.repository, Some("iterative-works/iw-cli"))
     assertEquals(config.teamPrefix, Some("IWCLI"))
 
-  test("ConfigSerializer requires team prefix for GitHub tracker"):
+  test("ConfigSerializer succeeds when GitHub config missing teamPrefix"):
     val hocon = """
       tracker {
         type = github
@@ -282,8 +285,11 @@ class ConfigTest extends munit.FunSuite:
       }
     """
     val result = ConfigSerializer.fromHocon(hocon)
-    assert(result.isLeft)
-    assert(result.left.getOrElse("").contains("teamPrefix required for GitHub tracker"))
+    assert(result.isRight)
+    val config = result.getOrElse(fail("Expected Right"))
+    assertEquals(config.trackerType, IssueTrackerType.GitHub)
+    assertEquals(config.repository, Some("iterative-works/iw-cli"))
+    assertEquals(config.teamPrefix, None)
 
   test("ConfigSerializer validates team prefix format - rejects lowercase"):
     val hocon = """
@@ -640,7 +646,7 @@ class ConfigTest extends munit.FunSuite:
     val config = result.getOrElse(fail("Expected Right"))
     assertEquals(config.repository, Some("group/subgroup/project"))
 
-  test("ConfigSerializer requires repository for GitLab tracker"):
+  test("ConfigSerializer succeeds when GitLab config missing repository"):
     val hocon = """
       tracker {
         type = gitlab
@@ -651,10 +657,13 @@ class ConfigTest extends munit.FunSuite:
       }
     """
     val result = ConfigSerializer.fromHocon(hocon)
-    assert(result.isLeft)
-    assert(result.left.getOrElse("").contains("repository required for GitLab tracker"))
+    assert(result.isRight)
+    val config = result.getOrElse(fail("Expected Right"))
+    assertEquals(config.trackerType, IssueTrackerType.GitLab)
+    assertEquals(config.repository, None)
+    assertEquals(config.teamPrefix, Some("PROJ"))
 
-  test("ConfigSerializer requires teamPrefix for GitLab tracker"):
+  test("ConfigSerializer succeeds when GitLab config missing teamPrefix"):
     val hocon = """
       tracker {
         type = gitlab
@@ -665,8 +674,11 @@ class ConfigTest extends munit.FunSuite:
       }
     """
     val result = ConfigSerializer.fromHocon(hocon)
-    assert(result.isLeft)
-    assert(result.left.getOrElse("").contains("teamPrefix required for GitLab tracker"))
+    assert(result.isRight)
+    val config = result.getOrElse(fail("Expected Right"))
+    assertEquals(config.trackerType, IssueTrackerType.GitLab)
+    assertEquals(config.repository, Some("owner/project"))
+    assertEquals(config.teamPrefix, None)
 
   test("ConfigSerializer validates GitLab repository format"):
     val hocon = """
@@ -778,3 +790,72 @@ class ConfigTest extends munit.FunSuite:
       projectName = "test"
     )
     assertEquals(config.teamIdentifier, "TEST")
+
+  // ========== extractRepositoryPath Tests ==========
+
+  test("extractRepositoryPath succeeds for GitHub HTTPS URL"):
+    val remote = GitRemote("https://github.com/iterative-works/iw-cli.git")
+    assertEquals(remote.extractRepositoryPath, Right("iterative-works/iw-cli"))
+
+  test("extractRepositoryPath succeeds for GitHub SSH URL"):
+    val remote = GitRemote("git@github.com:iterative-works/iw-cli.git")
+    assertEquals(remote.extractRepositoryPath, Right("iterative-works/iw-cli"))
+
+  test("extractRepositoryPath succeeds for GitLab HTTPS URL"):
+    val remote = GitRemote("https://gitlab.com/owner/repo.git")
+    assertEquals(remote.extractRepositoryPath, Right("owner/repo"))
+
+  test("extractRepositoryPath succeeds for GitLab SSH URL"):
+    val remote = GitRemote("git@gitlab.com:owner/repo.git")
+    assertEquals(remote.extractRepositoryPath, Right("owner/repo"))
+
+  test("extractRepositoryPath succeeds for self-hosted GitLab"):
+    val remote = GitRemote("https://gitlab.e-bs.cz/iterative-works/kanon.git")
+    assertEquals(remote.extractRepositoryPath, Right("iterative-works/kanon"))
+
+  test("extractRepositoryPath succeeds for GitLab nested groups"):
+    val remote = GitRemote("https://gitlab.com/group/subgroup/project.git")
+    assertEquals(remote.extractRepositoryPath, Right("group/subgroup/project"))
+
+  test("extractRepositoryPath fails for non-GitHub non-GitLab URL"):
+    val remote = GitRemote("https://bitbucket.org/owner/repo.git")
+    assert(remote.extractRepositoryPath.isLeft)
+
+  // ========== YouTrack with optional repository ==========
+
+  test("ConfigSerializer deserializes YouTrack config with optional repository"):
+    val hocon = """
+      tracker {
+        type = youtrack
+        team = TEST
+        repository = "iterative-works/kanon"
+        baseUrl = "https://youtrack.example.com"
+      }
+      project {
+        name = test-project
+      }
+    """
+    val result = ConfigSerializer.fromHocon(hocon)
+    assert(result.isRight)
+    val config = result.getOrElse(fail("Expected Right"))
+    assertEquals(config.trackerType, IssueTrackerType.YouTrack)
+    assertEquals(config.team, "TEST")
+    assertEquals(config.repository, Some("iterative-works/kanon"))
+    assertEquals(config.youtrackBaseUrl, Some("https://youtrack.example.com"))
+
+  test("ConfigSerializer round-trip for YouTrack config with repository"):
+    val original = ProjectConfiguration.create(
+      trackerType = IssueTrackerType.YouTrack,
+      team = "TEST",
+      projectName = "test-project",
+      repository = Some("iterative-works/kanon"),
+      youtrackBaseUrl = Some("https://youtrack.example.com")
+    )
+    val hocon = ConfigSerializer.toHocon(original)
+    val result = ConfigSerializer.fromHocon(hocon)
+    assert(result.isRight)
+    val roundTripped = result.getOrElse(fail("Expected Right"))
+    assertEquals(roundTripped.trackerType, original.trackerType)
+    assertEquals(roundTripped.team, original.team)
+    assertEquals(roundTripped.repository, original.repository)
+    assertEquals(roundTripped.youtrackBaseUrl, original.youtrackBaseUrl)


### PR DESCRIPTION
## Summary
- Add `GitRemote.extractRepositoryPath` that tries GitHub then GitLab URL extraction, fixing the fallback in `phase-pr` that only worked for GitHub remotes
- Make `repository`, `teamPrefix`, and `team` optional in config serialization for all tracker types, so YouTrack projects can set `tracker.repository` for their GitLab forge
- Unified `toHocon` to write all fields when present regardless of tracker type

## Test plan
- [x] `scala-cli compile --scalac-option -Werror .iw/core/` passes
- [x] `./iw test unit` passes (updated 5 existing tests, added 9 new tests)
- [x] `./iw test compile` passes (all 32 commands)
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)