### PR TITLE
Fail phase-commit when impl tasks are unchecked

### DIFF
--- a/.iw/commands/phase-commit.scala
+++ b/.iw/commands/phase-commit.scala
@@ -35,6 +35,20 @@ import iw.core.output.*
     PhaseArgs.resolvePhaseNumber(PhaseArgs.namedArg(argList, "--phase-number"), phaseNumRaw)
   )
 
+  val taskFilePath = os.pwd / "project-management" / "issues" / issueId.value / s"phase-${phaseNumber.value}-tasks.md"
+  if os.exists(taskFilePath) then
+    val taskContent = os.read(taskFilePath)
+    val unchecked = PhaseTaskFile.findUncheckedImplTasks(taskContent)
+    if unchecked.nonEmpty then
+      Output.error("Cannot commit phase with unchecked tasks.")
+      Output.error("")
+      Output.error("The following tasks are not marked as implemented:")
+      unchecked.foreach(line => Output.error(s"  $line"))
+      Output.error("")
+      Output.error(s"If these tasks have been implemented, check them off in phase-${phaseNumber.value}-tasks.md and retry.")
+      Output.error("If they have NOT been implemented, complete them before committing.")
+      sys.exit(1)
+
   CommandHelpers.exitOnError(GitAdapter.stageAll(os.pwd))
 
   val message = CommitMessage.build(title, items)
@@ -45,7 +59,6 @@ import iw.core.output.*
     case Left(_)      => 0
     case Right(files) => files.length
 
-  val taskFilePath = os.pwd / "project-management" / "issues" / issueId.value / s"phase-${phaseNumber.value}-tasks.md"
   if os.exists(taskFilePath) then
     val content = os.read(taskFilePath)
     val afterComplete = PhaseTaskFile.markComplete(content)

--- a/.iw/core/model/PhaseTaskFile.scala
+++ b/.iw/core/model/PhaseTaskFile.scala
@@ -37,6 +37,18 @@ object PhaseTaskFile:
   private val ReviewablePattern =
     """^(- \[x\] \[[^\]]+\]) \[ \] \[reviewed\](.*)$""".r
 
+  // Matches lines where primary checkbox is unchecked and tag is [impl]
+  private val UncheckedImplPattern =
+    """^- \[ \] \[impl\].*$""".r
+
+  /** Find all unchecked [impl] task lines.
+    *
+    * @param content Full markdown file content
+    * @return List of lines with unchecked [impl] tasks
+    */
+  def findUncheckedImplTasks(content: String): List[String] =
+    content.split("\n", -1).filter(UncheckedImplPattern.matches).toList
+
   /** Mark all checked tasks as [reviewed] where a [reviewed] marker exists.
     *
     * For lines matching `- [x] [tag] [ ] [reviewed]`,

--- a/.iw/core/test/PhaseTaskFileTest.scala
+++ b/.iw/core/test/PhaseTaskFileTest.scala
@@ -93,3 +93,57 @@ class PhaseTaskFileTest extends FunSuite:
       "- [ ] [impl] [ ] [reviewed] Not done yet\n" +
       "- [x] [test] [x] [reviewed] Test task\n"
     )
+
+  // findUncheckedImplTasks tests
+
+  test("findUncheckedImplTasks returns empty list when all impl tasks are checked"):
+    val content =
+      "- [x] [impl] [x] [reviewed] Task one\n" +
+      "- [x] [impl] Task two\n" +
+      "- [x] [test] [x] [reviewed] Test task\n"
+    assertEquals(PhaseTaskFile.findUncheckedImplTasks(content), Nil)
+
+  test("findUncheckedImplTasks finds unchecked impl tasks with reviewed marker"):
+    val content =
+      "- [x] [impl] [x] [reviewed] Done task\n" +
+      "- [ ] [impl] [ ] [reviewed] Not done task\n"
+    assertEquals(
+      PhaseTaskFile.findUncheckedImplTasks(content),
+      List("- [ ] [impl] [ ] [reviewed] Not done task")
+    )
+
+  test("findUncheckedImplTasks finds unchecked impl tasks without reviewed marker"):
+    val content =
+      "- [x] [impl] Done task\n" +
+      "- [ ] [impl] Not done task\n"
+    assertEquals(
+      PhaseTaskFile.findUncheckedImplTasks(content),
+      List("- [ ] [impl] Not done task")
+    )
+
+  test("findUncheckedImplTasks ignores unchecked non-impl tasks"):
+    val content =
+      "- [ ] [test] Unchecked test\n" +
+      "- [ ] [setup] Unchecked setup\n" +
+      "- [ ] [int] Unchecked integration\n"
+    assertEquals(PhaseTaskFile.findUncheckedImplTasks(content), Nil)
+
+  test("findUncheckedImplTasks finds multiple unchecked impl tasks"):
+    val content =
+      "- [ ] [impl] [ ] [reviewed] First unchecked\n" +
+      "- [x] [impl] [x] [reviewed] Done\n" +
+      "- [ ] [impl] [ ] [reviewed] Second unchecked\n"
+    assertEquals(
+      PhaseTaskFile.findUncheckedImplTasks(content),
+      List(
+        "- [ ] [impl] [ ] [reviewed] First unchecked",
+        "- [ ] [impl] [ ] [reviewed] Second unchecked"
+      )
+    )
+
+  test("findUncheckedImplTasks returns empty list for content with no task lines"):
+    val content = "# Phase 1\n\nSome description.\n\n**Phase Status:** Not Started\n"
+    assertEquals(PhaseTaskFile.findUncheckedImplTasks(content), Nil)
+
+  test("findUncheckedImplTasks returns empty list for empty content"):
+    assertEquals(PhaseTaskFile.findUncheckedImplTasks(""), Nil)


### PR DESCRIPTION
## Summary
- Add `PhaseTaskFile.findUncheckedImplTasks` to detect `- [ ] [impl]` lines in phase task files
- `phase-commit` now validates before staging — if any `[impl]` tasks are unchecked, it fails with a descriptive error listing the unchecked tasks
- Prevents silent completion of phases where the agent forgot to check off tasks

## Test plan
- [x] 7 new unit tests for `findUncheckedImplTasks` (empty list, with/without reviewed marker, ignores non-impl, multiple unchecked, no task lines, empty content)
- [x] `scala-cli compile --scalac-option -Werror .iw/core/` passes
- [x] `./iw test unit` passes
- [x] `./iw test compile` passes (all 32 commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)