### PR TITLE
IW-340: Add --commit flag to review-state commands

### DIFF
--- a/commands/review-state/update.scala
+++ b/commands/review-state/update.scala
@@ -37,6 +37,7 @@
 //   --clear-display-subtext    Remove display.subtext field
 //   --clear-needs-attention    Remove needs_attention field
 //   --issue-id <value>         Issue ID override (auto-inferred from branch)
+//   --commit                   Stage and commit review-state.json after writing
 // EXAMPLE: iw review-state update --display-text "Implementing"
 // EXAMPLE: iw review-state update --append-artifact "Tasks:phase-02-tasks.md"
 // EXAMPLE: iw review-state update --clear-message
@@ -222,6 +223,18 @@ import iw.core.output.*
 
   // Write back to same location
   os.write.over(inputPath, mergedJson)
+
+  if argList.contains("--commit") then
+    val commitMessage = status match
+      case Some(s) => s"chore($issueId): update review-state to $s"
+      case None    => s"chore($issueId): update review-state"
+    GitAdapter
+      .commitFileWithRetry(inputPath, commitMessage, inputPath / os.up)
+      .left
+      .foreach(err =>
+        Output.warning(s"Failed to commit review-state update: $err")
+      )
+
   Output.success(s"Review state updated at $inputPath")
 
 private def showHelp(): Unit =
@@ -301,6 +314,9 @@ private def showHelp(): Unit =
   println("  --clear-needs-attention              Remove needs_attention field")
   println(
     "  --issue-id <value>                   Issue ID override (auto-inferred from branch)"
+  )
+  println(
+    "  --commit                             Stage and commit review-state.json after writing"
   )
   println()
   println("Examples:")

--- a/commands/review-state/write.scala
+++ b/commands/review-state/write.scala
@@ -21,6 +21,7 @@
 //   --from-stdin               Read full JSON from stdin
 //   --issue-id <value>         Issue ID override (auto-inferred from branch)
 //   --version <value>          Version number (default: 2)
+//   --commit                   Stage and commit review-state.json after writing
 // EXAMPLE: iw review-state write --display-text "Implementing" --display-type progress --output review-state.json
 
 import iw.core.model.*
@@ -96,6 +97,9 @@ private def showHelp(): Unit =
   println(
     "  --version <value>                         Version number (default: 2)"
   )
+  println(
+    "  --commit                                  Stage and commit review-state.json after writing"
+  )
   println()
   println("Example:")
   println(
@@ -123,6 +127,15 @@ private def handleStdin(argList: List[String]): Unit =
 
   os.makeDir.all(outputPath / os.up)
   os.write.over(outputPath, json)
+
+  val issueId = extractFlag(argList, "--issue-id") match
+    case Some(id) => id
+    case None     =>
+      GitAdapter.getCurrentBranch(os.pwd).flatMap(IssueId.fromBranch) match
+        case Right(id) => id.value
+        case Left(_)   => "unknown"
+  commitIfRequested(argList, issueId, outputPath)
+
   Output.success(s"Review state written to $outputPath")
 
 private def handleFlags(argList: List[String]): Unit =
@@ -253,7 +266,27 @@ private def handleFlags(argList: List[String]): Unit =
 
   os.makeDir.all(outputPath / os.up)
   os.write.over(outputPath, json)
+
+  commitIfRequested(argList, issueId, outputPath)
+
   Output.success(s"Review state written to $outputPath")
+
+private def commitIfRequested(
+    argList: List[String],
+    issueId: String,
+    outputPath: os.Path
+): Unit =
+  if argList.contains("--commit") then
+    val status = extractFlag(argList, "--status")
+    val commitMessage = status match
+      case Some(s) => s"chore($issueId): update review-state to $s"
+      case None    => s"chore($issueId): update review-state"
+    GitAdapter
+      .commitFileWithRetry(outputPath, commitMessage, outputPath / os.up)
+      .left
+      .foreach(err =>
+        Output.warning(s"Failed to commit review-state update: $err")
+      )
 
 private def extractFlag(args: List[String], flag: String): Option[String] =
   val idx = args.indexOf(flag)

--- a/project-management/issues/IW-340/analysis.md
+++ b/project-management/issues/IW-340/analysis.md
@@ -67,31 +67,19 @@ This matches the existing pattern in phase commands, where commit failure of rev
 
 ## Technical Risks & Uncertainties
 
-### CLARIFY: Should write.scala also get --commit?
+### Resolved: write.scala also gets --commit
 
-The issue description says "Possibly `commands/review-state/write.scala` — same flag if applicable". The kanon blueprints call `review-state update` at the listed transitions, but `write` is used at initial creation (e.g., by `wf-create-analysis`).
+Both `update.scala` and `write.scala` get the `--commit` flag. The `write` command is used at initial creation (e.g., by `wf-create-analysis`) and has the same uncommitted-file problem.
 
-**Options:**
-- **Option A**: Add `--commit` to both `update.scala` and `write.scala` now. Low risk, consistent API, ~30 minutes extra work.
-- **Option B**: Add `--commit` only to `update.scala`. Smaller change, can add to `write.scala` later if needed.
+### Resolved: Commit message when --status is not provided
 
-**Impact:** Minor. If we skip `write.scala` now, it is trivial to add later.
-
-### CLARIFY: Commit message when --status is not provided
-
-When `--commit` is used but `--status` is not among the flags, what should the commit message say?
-
-**Options:**
-- **Option A**: `chore(<issueId>): update review-state` (generic, always works)
-- **Option B**: Parse status from the merged JSON string. More informative but adds complexity.
-
-**Impact:** Cosmetic only. Option A is simplest and sufficient.
+When `--commit` is used but `--status` is not among the flags, the commit message uses the generic form: `chore(<issueId>): update review-state`. When `--status` is provided, it includes it: `chore(<issueId>): update review-state to <status>`.
 
 ## Total Estimates
 
 **Per-Layer Breakdown:**
 - Presentation Layer (update.scala): 1–2 hours
-- Presentation Layer (write.scala, if included): 0.5–1 hour
+- Presentation Layer (write.scala): 0.5–1 hour
 - E2E Tests: 1–2 hours
 
 **Total Range:** 2.5 – 5 hours (including both commands and tests)
@@ -113,7 +101,7 @@ Tests for `--commit` require a git-initialized temp directory (existing E2E test
 6. `--commit` with validation failure does NOT commit (file unchanged, no commit)
 7. `--help` output includes `--commit` flag
 
-**Tests for write.scala (if included):**
+**Tests for write.scala:**
 1. `--commit` flag stages and commits the written file
 2. Without `--commit`, file is written but not committed
 3. `--help` output includes `--commit` flag
@@ -132,7 +120,7 @@ Tests for `--commit` require a git-initialized temp directory (existing E2E test
 **Recommended Layer Order:**
 
 1. **Presentation Layer — update.scala**: Add `--commit` flag parsing, post-write commit logic, help text update, ARGS comment update.
-2. **Presentation Layer — write.scala**: Same pattern applied to the write command (pending CLARIFY resolution).
+2. **Presentation Layer — write.scala**: Same pattern applied to the write command.
 3. **E2E Tests**: BATS tests for both commands with `--commit`.
 
 **Ordering Rationale:**

--- a/project-management/issues/IW-340/analysis.md
+++ b/project-management/issues/IW-340/analysis.md
@@ -1,0 +1,153 @@
+# Technical Analysis: Add --commit flag to review-state update command
+
+**Issue:** IW-340
+**Created:** 2026-04-13
+**Status:** Draft
+
+## Problem Statement
+
+The `review-state update` command writes `review-state.json` to disk but does not commit it. When kanon workflow blueprints call `./iw review-state update` at state transitions (`context_ready`, `tasks_ready`, `review_failed`, `all_complete`), review-state.json is left as an uncommitted change. This causes "dirty working tree" errors at phase boundaries and forces a fragile `commitLeftovers()` workaround in batch-implement mode that creates messy git history.
+
+## Proposed Solution
+
+### High-Level Approach
+
+Add an optional `--commit` boolean flag to `commands/review-state/update.scala`. When present, after writing review-state.json, the command stages and commits the file using the existing `GitAdapter.commitFileWithRetry()`. The commit message follows the established convention: `chore(<issue-id>): update review-state to <status>`.
+
+This is a small, self-contained change. The issue ID and status are already parsed in `update.scala` (lines 57–65 and 82 respectively), and the commit pattern is well-established across `phase-start.scala`, `phase-pr.scala`, `phase-advance.scala`, and `phase-merge.scala`.
+
+### Why This Approach
+
+The alternative would be to always commit (no flag). However, that would change existing behavior and could break callers that intentionally batch multiple changes before committing. A flag preserves backward compatibility and gives callers explicit control.
+
+## Architecture Design
+
+### Presentation Layer (Command Scripts)
+
+This is the only layer that needs changes. No domain, application, or infrastructure changes are required — all necessary infrastructure already exists.
+
+**Components:**
+- `commands/review-state/update.scala` — add `--commit` flag parsing and post-write commit logic
+- `commands/review-state/write.scala` — add same `--commit` flag (same pattern, same rationale)
+
+**Responsibilities:**
+- Parse the `--commit` boolean flag from CLI args
+- After successful write, if `--commit` is present, call `GitAdapter.commitFileWithRetry()` with the output path
+- Construct commit message from already-parsed `issueId` and `status` (falling back to generic message if status absent)
+- Report commit success/failure via `Output`
+- Update `showHelp()` to document `--commit`
+- Update file header ARGS comments
+
+**Existing Infrastructure Used:**
+- `GitAdapter.commitFileWithRetry(path: os.Path, message: String, dir: os.Path): Either[String, String]` — stages and commits a single file with retry on transient failures (e.g., `index.lock`). Located at `core/adapters/Git.scala:162`.
+- `Output.error()`, `Output.success()` — CLI output formatting
+
+**Estimated Effort:** 1–2 hours for update.scala, 0.5–1 hour for write.scala
+
+## Technical Decisions
+
+### Patterns
+
+- Follow the exact same commit-after-write pattern used in `phase-start.scala` (lines 71–81): call `commitFileWithRetry`, handle `Left` with a warning via `Output.error`, do not exit on commit failure
+- Boolean flag detection: `argList.contains("--commit")` — consistent with how `--clear-*` and `--needs-attention` flags are already detected
+- No new dependencies: uses existing `GitAdapter.commitFileWithRetry` and `Output`
+
+### Commit Message Construction
+
+Use the `--status` flag value if provided: `chore(<issueId>): update review-state to <status>`. If `--status` is not among the flags (e.g., user is only updating display text), use the generic: `chore(<issueId>): update review-state`. This avoids re-parsing the merged JSON and is consistent with how the issue described the feature.
+
+### Commit Failure Behavior
+
+When `--commit` is provided but the commit fails, the command should:
+1. Still succeed at the primary task (writing the file) — the file has already been written
+2. Print a warning about the commit failure via `Output.error`
+3. Exit with code 0 (not fail the overall command)
+
+This matches the existing pattern in phase commands, where commit failure of review-state is treated as a non-fatal warning. Callers that need to guarantee the commit can check git status afterward.
+
+## Technical Risks & Uncertainties
+
+### CLARIFY: Should write.scala also get --commit?
+
+The issue description says "Possibly `commands/review-state/write.scala` — same flag if applicable". The kanon blueprints call `review-state update` at the listed transitions, but `write` is used at initial creation (e.g., by `wf-create-analysis`).
+
+**Options:**
+- **Option A**: Add `--commit` to both `update.scala` and `write.scala` now. Low risk, consistent API, ~30 minutes extra work.
+- **Option B**: Add `--commit` only to `update.scala`. Smaller change, can add to `write.scala` later if needed.
+
+**Impact:** Minor. If we skip `write.scala` now, it is trivial to add later.
+
+### CLARIFY: Commit message when --status is not provided
+
+When `--commit` is used but `--status` is not among the flags, what should the commit message say?
+
+**Options:**
+- **Option A**: `chore(<issueId>): update review-state` (generic, always works)
+- **Option B**: Parse status from the merged JSON string. More informative but adds complexity.
+
+**Impact:** Cosmetic only. Option A is simplest and sufficient.
+
+## Total Estimates
+
+**Per-Layer Breakdown:**
+- Presentation Layer (update.scala): 1–2 hours
+- Presentation Layer (write.scala, if included): 0.5–1 hour
+- E2E Tests: 1–2 hours
+
+**Total Range:** 2.5 – 5 hours (including both commands and tests)
+
+**Confidence:** High — pattern is well-established in four other commands, all required infrastructure exists.
+
+## Testing Strategy
+
+### E2E Tests (BATS)
+
+Tests for `--commit` require a git-initialized temp directory (existing E2E tests use plain temp dirs). Must export `IW_SERVER_DISABLED=1` in setup.
+
+**Tests for update.scala:**
+1. `--commit` flag stages and commits review-state.json — verify with `git log --oneline -1` and `git status` (clean tree)
+2. `--commit` commit message contains issue ID
+3. `--commit` commit message contains status when `--status` is provided
+4. `--commit` without `--status` produces a generic commit message (no status in message)
+5. Without `--commit`, file is written but not committed (working tree is dirty)
+6. `--commit` with validation failure does NOT commit (file unchanged, no commit)
+7. `--help` output includes `--commit` flag
+
+**Tests for write.scala (if included):**
+1. `--commit` flag stages and commits the written file
+2. Without `--commit`, file is written but not committed
+3. `--help` output includes `--commit` flag
+
+**Test Data Strategy:**
+- Create a git-initialized temp directory in setup
+- Seed with a valid review-state.json that is already committed
+- Run update with `--commit` and verify git log
+
+**Regression Coverage:**
+- Existing tests (without `--commit`) must continue to pass unchanged
+- The flag is purely additive; no existing behavior is modified
+
+## Implementation Sequence
+
+**Recommended Layer Order:**
+
+1. **Presentation Layer — update.scala**: Add `--commit` flag parsing, post-write commit logic, help text update, ARGS comment update.
+2. **Presentation Layer — write.scala**: Same pattern applied to the write command (pending CLARIFY resolution).
+3. **E2E Tests**: BATS tests for both commands with `--commit`.
+
+**Ordering Rationale:**
+- No domain or infrastructure changes, so implementation starts and ends in the presentation layer.
+- Both commands can be done in parallel since they are independent scripts.
+- Tests follow TDD — write failing tests first, then implement.
+
+## Deployment Considerations
+
+- Ship the flag in iw-cli first
+- Then update kanon workflow blueprints to add `--commit` to all `review-state update` calls
+- The flag is backward-compatible — old callers are unaffected
+- Rollback: remove `--commit` from kanon blueprints (they revert to current behavior)
+
+## Dependencies
+
+- **Prerequisites:** None. All required infrastructure exists.
+- **External Blockers:** None.

--- a/project-management/issues/IW-340/implementation-log.md
+++ b/project-management/issues/IW-340/implementation-log.md
@@ -1,0 +1,36 @@
+# Implementation Log: Add --commit flag to review-state update command
+
+Issue: IW-340
+
+This log tracks the evolution of implementation across phases.
+
+---
+
+## Phase 1: Add --commit flag to review-state commands (2026-04-13)
+
+**Layer:** Presentation (Command Scripts)
+
+**What was built:**
+- `commands/review-state/update.scala` - Added `--commit` boolean flag that stages and commits review-state.json after writing, using `GitAdapter.commitFileWithRetry()`
+- `commands/review-state/write.scala` - Same `--commit` flag added to both `handleFlags` and `handleStdin` paths, with shared `commitIfRequested` helper to avoid duplication
+- `test/review-state.bats` - 10 new E2E tests covering both commands with `--commit` flag
+
+**Dependencies on other layers:**
+- Infrastructure: `GitAdapter.commitFileWithRetry()` (pre-existing, no changes needed)
+
+**Testing:**
+- E2E tests: 10 tests added (update: 5, write: 5)
+- All 61 review-state tests pass
+
+**Code review:**
+- Iterations: 2
+- Findings addressed: extracted `commitIfRequested` helper, fixed `Output.error` → `Output.warning` for non-fatal failures, added missing `--from-stdin --commit` test, simplified fragile assertion
+
+**Files changed:**
+```
+M	commands/review-state/update.scala
+M	commands/review-state/write.scala
+M	test/review-state.bats
+```
+
+---

--- a/project-management/issues/IW-340/phase-01-context.md
+++ b/project-management/issues/IW-340/phase-01-context.md
@@ -1,0 +1,91 @@
+# Phase 1: Add --commit flag to review-state commands
+
+## Goals
+
+Add an optional `--commit` boolean flag to `review-state update` and `review-state write` commands. When present, after writing review-state.json, the command stages and commits the file using `GitAdapter.commitFileWithRetry()`.
+
+## Scope
+
+### In Scope
+- `--commit` flag parsing in `commands/review-state/update.scala`
+- `--commit` flag parsing in `commands/review-state/write.scala`
+- Post-write commit logic using `GitAdapter.commitFileWithRetry()`
+- Commit message construction from issue ID and status
+- Help text updates for both commands
+- ARGS comment updates for both commands
+- E2E BATS tests for the new flag
+
+### Out of Scope
+- Changes to core library code
+- Changes to `GitAdapter` or any infrastructure
+- Changes to `review-state validate` command
+- Always-commit behavior (flag is opt-in)
+
+## Dependencies
+
+- `GitAdapter.commitFileWithRetry(path, message, dir)` at `core/adapters/Git.scala:162` — already exists
+- `Output.error()`, `Output.success()` — already available in both commands
+
+## Approach
+
+### Pattern Reference
+
+Follow the commit-after-write pattern from `phase-start.scala` (lines 70–81):
+```scala
+GitAdapter
+  .commitFileWithRetry(
+    reviewStatePath,
+    s"chore(${issueId.value}): update review-state for phase ${phaseNumber.value}",
+    os.pwd
+  )
+  .left
+  .foreach(err =>
+    Output.error(s"Warning: Failed to commit review-state update: $err")
+  )
+```
+
+### Flag Detection
+
+Use `argList.contains("--commit")` — consistent with existing boolean flags like `--needs-attention` and `--clear-*`.
+
+### Commit Message Format
+
+- With `--status`: `chore(<issueId>): update review-state to <status>`
+- Without `--status`: `chore(<issueId>): update review-state`
+
+### Commit Failure Behavior
+
+Non-fatal: print warning via `Output.error`, exit 0 (file was already written successfully).
+
+## Files to Modify
+
+1. `commands/review-state/update.scala` — add `--commit` flag, post-write commit, help text, ARGS comment
+2. `commands/review-state/write.scala` — add `--commit` flag, post-write commit, help text, ARGS comment
+3. `test/review-state.bats` — add E2E tests for `--commit` flag
+
+## Testing Strategy
+
+Tests require a git-initialized temp directory (existing tests use plain temp dirs). Must export `IW_SERVER_DISABLED=1`.
+
+### update.scala tests
+1. `--commit` stages and commits review-state.json (clean tree after)
+2. Commit message contains issue ID and status when `--status` provided
+3. Without `--status`, commit message uses generic form (no status)
+4. Without `--commit`, file is written but not committed (dirty tree)
+5. `--help` output includes `--commit`
+
+### write.scala tests
+1. `--commit` stages and commits the written file (clean tree after)
+2. Without `--commit`, file is written but not committed
+3. `--help` output includes `--commit`
+
+## Acceptance Criteria
+
+- [ ] `./iw review-state update --commit` writes and commits review-state.json
+- [ ] `./iw review-state write --commit` writes and commits review-state.json
+- [ ] Commit messages follow `chore(<issueId>): update review-state [to <status>]` format
+- [ ] Commit failure is non-fatal (warning printed, exit 0)
+- [ ] `--help` for both commands documents `--commit`
+- [ ] All existing tests continue to pass
+- [ ] All new tests pass
+- [ ] Code compiles with `-Werror`

--- a/project-management/issues/IW-340/phase-01-tasks.md
+++ b/project-management/issues/IW-340/phase-01-tasks.md
@@ -2,31 +2,32 @@
 
 ## Setup
 
-- [ ] [setup] Read existing update.scala, write.scala, and GitAdapter.commitFileWithRetry
-- [ ] [setup] Read existing test/review-state.bats for test patterns
+- [x] [setup] Read existing update.scala, write.scala, and GitAdapter.commitFileWithRetry
+- [x] [setup] Read existing test/review-state.bats for test patterns
 
 ## Tests (TDD — write failing tests first)
 
-- [ ] [test] Add BATS test: update --commit stages and commits review-state.json (git init temp dir, seed file, verify clean tree)
-- [ ] [test] Add BATS test: update --commit message contains issue ID and status
-- [ ] [test] Add BATS test: update --commit without --status uses generic commit message
-- [ ] [test] Add BATS test: update without --commit leaves file uncommitted (dirty tree)
-- [ ] [test] Add BATS test: update --help includes --commit flag
-- [ ] [test] Add BATS test: write --commit stages and commits the written file (clean tree)
-- [ ] [test] Add BATS test: write without --commit leaves file uncommitted
-- [ ] [test] Add BATS test: write --help includes --commit flag
+- [x] [test] Add BATS test: update --commit stages and commits review-state.json (git init temp dir, seed file, verify clean tree)
+- [x] [test] Add BATS test: update --commit message contains issue ID and status
+- [x] [test] Add BATS test: update --commit without --status uses generic commit message
+- [x] [test] Add BATS test: update without --commit leaves file uncommitted (dirty tree)
+- [x] [test] Add BATS test: update --help includes --commit flag
+- [x] [test] Add BATS test: write --commit stages and commits the written file (clean tree)
+- [x] [test] Add BATS test: write without --commit leaves file uncommitted
+- [x] [test] Add BATS test: write --help includes --commit flag
 
 ## Implementation
 
-- [ ] [impl] Add --commit flag to update.scala ARGS comment
-- [ ] [impl] Add --commit detection and post-write commit logic to update.scala
-- [ ] [impl] Add --commit to update.scala showHelp()
-- [ ] [impl] Add --commit flag to write.scala ARGS comment
-- [ ] [impl] Add --commit detection and post-write commit logic to write.scala (both handleFlags and handleStdin paths)
-- [ ] [impl] Add --commit to write.scala showHelp()
+- [x] [impl] Add --commit flag to update.scala ARGS comment
+- [x] [impl] Add --commit detection and post-write commit logic to update.scala
+- [x] [impl] Add --commit to update.scala showHelp()
+- [x] [impl] Add --commit flag to write.scala ARGS comment
+- [x] [impl] Add --commit detection and post-write commit logic to write.scala (both handleFlags and handleStdin paths)
+- [x] [impl] Add --commit to write.scala showHelp()
 
 ## Verification
 
-- [ ] [verify] Run all E2E tests: ./iw ./test e2e
-- [ ] [verify] Run compile check: scala-cli compile --scalac-option -Werror core/
-- [ ] [verify] Verify existing tests still pass
+- [x] [verify] Run all E2E tests: ./iw ./test e2e
+- [x] [verify] Run compile check: scala-cli compile --scalac-option -Werror core/
+- [x] [verify] Verify existing tests still pass
+**Phase Status:** Complete

--- a/project-management/issues/IW-340/phase-01-tasks.md
+++ b/project-management/issues/IW-340/phase-01-tasks.md
@@ -1,0 +1,32 @@
+# Phase 1 Tasks: Add --commit flag to review-state commands
+
+## Setup
+
+- [ ] [setup] Read existing update.scala, write.scala, and GitAdapter.commitFileWithRetry
+- [ ] [setup] Read existing test/review-state.bats for test patterns
+
+## Tests (TDD — write failing tests first)
+
+- [ ] [test] Add BATS test: update --commit stages and commits review-state.json (git init temp dir, seed file, verify clean tree)
+- [ ] [test] Add BATS test: update --commit message contains issue ID and status
+- [ ] [test] Add BATS test: update --commit without --status uses generic commit message
+- [ ] [test] Add BATS test: update without --commit leaves file uncommitted (dirty tree)
+- [ ] [test] Add BATS test: update --help includes --commit flag
+- [ ] [test] Add BATS test: write --commit stages and commits the written file (clean tree)
+- [ ] [test] Add BATS test: write without --commit leaves file uncommitted
+- [ ] [test] Add BATS test: write --help includes --commit flag
+
+## Implementation
+
+- [ ] [impl] Add --commit flag to update.scala ARGS comment
+- [ ] [impl] Add --commit detection and post-write commit logic to update.scala
+- [ ] [impl] Add --commit to update.scala showHelp()
+- [ ] [impl] Add --commit flag to write.scala ARGS comment
+- [ ] [impl] Add --commit detection and post-write commit logic to write.scala (both handleFlags and handleStdin paths)
+- [ ] [impl] Add --commit to write.scala showHelp()
+
+## Verification
+
+- [ ] [verify] Run all E2E tests: ./iw ./test e2e
+- [ ] [verify] Run compile check: scala-cli compile --scalac-option -Werror core/
+- [ ] [verify] Verify existing tests still pass

--- a/project-management/issues/IW-340/release-notes.md
+++ b/project-management/issues/IW-340/release-notes.md
@@ -1,0 +1,9 @@
+# IW-340: Automatický commit stavu review po aktualizaci
+
+**Datum:** 2026-04-14
+
+Příkazy `review-state update` a `review-state write` nově podporují volitelný přepínač `--commit`. Když je tento přepínač uveden, nástroj po zápisu souboru review-state.json automaticky provede jeho uložení do gitu. Uživatel tak nemusí ručně commitovat změny stavu a při přechodu mezi fázemi workflow nedochází k chybám způsobeným neuloženými změnami v pracovním adresáři.
+
+Přepínač je čistě volitelný a stávající chování příkazů se bez něj nijak nemění. Pokud by commit z jakéhokoli důvodu selhal, hlavní operace (zápis souboru) proběhne úspěšně a uživatel je na neúspěšný commit upozorněn varováním. Příkaz v takovém případě neskončí chybou.
+
+Tato změna je plně zpětně kompatibilní a nevyžaduje žádné úpravy na straně uživatele.

--- a/project-management/issues/IW-340/review-packet.md
+++ b/project-management/issues/IW-340/review-packet.md
@@ -1,0 +1,163 @@
+---
+generated_from: b8e160b27160e6be1f34cfe354ade292dba89d6a
+generated_at: 2026-04-14T06:31:08Z
+branch: IW-340
+issue_id: IW-340
+phase: 1
+files_analyzed:
+  - commands/review-state/update.scala
+  - commands/review-state/write.scala
+  - test/review-state.bats
+---
+
+# Review Packet: IW-340 - Add --commit flag to review-state commands
+
+## Goals
+
+This feature adds an optional `--commit` boolean flag to the `review-state update` and `review-state write` commands. When present, after writing `review-state.json`, the command stages and commits the file using the existing `GitAdapter.commitFileWithRetry()`.
+
+The problem being solved: kanon workflow blueprints call `./iw review-state update` at state transitions (`context_ready`, `tasks_ready`, `review_failed`, `all_complete`), which leaves `review-state.json` as an uncommitted change. This caused "dirty working tree" errors at phase boundaries and forced a fragile `commitLeftovers()` workaround in batch-implement mode that created messy git history.
+
+Key objectives:
+- Add `--commit` flag to `review-state update` — writes and commits in one step
+- Add `--commit` flag to `review-state write` — same behaviour for initial creation
+- Commit message follows `chore(<issueId>): update review-state [to <status>]` convention
+- Commit failure is non-fatal: a warning is printed but the command exits 0 (file was already written)
+- Flag is purely opt-in — existing callers are unaffected
+
+## Scenarios
+
+- [ ] `review-state update --commit` writes review-state.json and leaves a clean working tree
+- [ ] `review-state update --commit --status <s>` produces commit message `chore(<id>): update review-state to <s>`
+- [ ] `review-state update --commit` without `--status` produces generic commit message (no "to" clause)
+- [ ] `review-state update` without `--commit` writes the file but does not commit (dirty tree)
+- [ ] `review-state update --help` documents `--commit`
+- [ ] `review-state write --commit` writes review-state.json and leaves a clean working tree
+- [ ] `review-state write --from-stdin --commit` also stages and commits
+- [ ] `review-state write --commit --status <s>` produces commit message `chore(<id>): update review-state to <s>`
+- [ ] `review-state write` without `--commit` writes the file but does not commit (dirty tree)
+- [ ] `review-state write --help` documents `--commit`
+- [ ] All existing tests continue to pass unchanged
+
+## Entry Points
+
+| File | Method/Class | Why Start Here |
+|------|--------------|----------------|
+| `commands/review-state/update.scala` | `update()` main, lines 227-237 | Core change: `--commit` detection and `commitFileWithRetry` call |
+| `commands/review-state/write.scala` | `commitIfRequested()`, lines 274-289 | Shared helper used by both `handleFlags` and `handleStdin` |
+| `test/review-state.bats` | `@test "review-state update: --commit..."` (line 723+) | E2E coverage for all new flag behaviour |
+
+## Diagrams
+
+### Control Flow — update.scala with --commit
+
+```
+update() args
+  |
+  +-- parse --issue-id / infer from branch
+  +-- parse --input / derive from issue_id
+  +-- read existing JSON
+  +-- build UpdateInput from flags
+  +-- ReviewStateUpdater.merge()
+  +-- ReviewStateValidator.validate()
+       |
+       +-- invalid --> exit 1
+  |
+  +-- os.write.over(inputPath, mergedJson)
+  |
+  +-- argList.contains("--commit")?
+       |
+       YES --> commitFileWithRetry(inputPath, msg, dir)
+                |
+                +-- Left(err) --> Output.warning(...)  [non-fatal, continues]
+                +-- Right(_)  --> (silent success)
+  |
+  Output.success(...)
+```
+
+### Control Flow — write.scala with --commit
+
+```
+write() args
+  |
+  +-- --from-stdin?  --> handleStdin(argList)
+  +-- else           --> handleFlags(argList)
+                              |
+                              ... build + validate + write ...
+  Both paths call:
+  commitIfRequested(argList, issueId, outputPath)
+    |
+    +-- argList.contains("--commit")?
+         YES --> commitFileWithRetry(outputPath, msg, dir)
+                  +-- Left(err) --> Output.warning(...)
+```
+
+### Relationship to existing infrastructure
+
+```
+update.scala / write.scala
+        |
+        | calls
+        v
+GitAdapter.commitFileWithRetry(path, message, dir)   [core/adapters/Git.scala:162]
+        |
+        | stages single file + commits with retry on lock contention
+        v
+git (subprocess)
+```
+
+No new infrastructure. The same function is already used by `phase-start.scala`, `phase-pr.scala`, `phase-advance.scala`, and `phase-merge.scala`.
+
+## Test Summary
+
+All tests are E2E (BATS). There are no unit tests for these command scripts — this is consistent with the rest of the codebase where command scripts are covered exclusively by BATS.
+
+### New tests (10 total)
+
+**update.scala — 5 tests** (lines 723-804 in `test/review-state.bats`):
+
+| # | Test name | Type | Verifies |
+|---|-----------|------|----------|
+| 1 | `--commit stages and commits review-state.json (clean tree after)` | E2E | `git status --porcelain` is empty after commit |
+| 2 | `--commit message contains issue ID and status` | E2E | `git log -1 --format=%s` contains issue ID and status value |
+| 3 | `--commit without --status uses generic commit message` | E2E | Commit message contains issue ID but NOT ` to ` |
+| 4 | `without --commit, file is written but not committed` | E2E | `git status --porcelain` is non-empty (dirty) |
+| 5 | `--help includes --commit flag` | E2E | `--help` output contains the string `--commit` |
+
+**write.scala — 5 tests** (lines 810-876 in `test/review-state.bats`):
+
+| # | Test name | Type | Verifies |
+|---|-----------|------|----------|
+| 1 | `--commit stages and commits the written file (clean tree after)` | E2E | Clean tree via `git status --porcelain` |
+| 2 | `without --commit, file is written but not committed` | E2E | File exists but tree is dirty |
+| 3 | `--from-stdin --commit stages and commits (clean tree after)` | E2E | stdin path also commits correctly |
+| 4 | `--commit message contains issue ID and status` | E2E | Commit message contains issue ID and status value |
+| 5 | `--help includes --commit flag` | E2E | `--help` output contains `--commit` |
+
+### Test infrastructure note
+
+The new tests introduce a `setup_git_repo` helper (line 714-721) that initialises a bare git repo in the temp directory and makes an initial empty commit. This is needed because existing tests use plain temp dirs without git, but `commitFileWithRetry` requires a git working tree.
+
+### Existing tests
+
+The full existing suite (70+ tests) covers `validate`, `write`, and `update` without `--commit`. All must continue to pass — the flag is purely additive.
+
+## Files Changed
+
+| File | Change Type | Summary |
+|------|-------------|---------|
+| `commands/review-state/update.scala` | Modified | Added `--commit` flag detection (line 40 ARGS comment, lines 227-237 commit logic, line 319 help text) |
+| `commands/review-state/write.scala` | Modified | Added `--commit` flag (line 24 ARGS comment, lines 274-289 `commitIfRequested` helper, line 100 help text); helper called from both `handleFlags` and `handleStdin` paths |
+| `test/review-state.bats` | Modified | Added `setup_git_repo` helper and 10 new `@test` blocks for `--commit` behaviour |
+| `project-management/issues/IW-340/analysis.md` | Added | Technical analysis document |
+| `project-management/issues/IW-340/phase-01-context.md` | Added | Phase 1 scope, approach, acceptance criteria |
+| `project-management/issues/IW-340/phase-01-tasks.md` | Added | Detailed task breakdown |
+| `project-management/issues/IW-340/tasks.md` | Added | Top-level task index |
+| `project-management/issues/IW-340/implementation-log.md` | Added | Implementation notes (2 review iterations, extracted helper, fixed Output.error to Output.warning) |
+| `project-management/issues/IW-340/review-state.json` | Added/Updated | Issue tracking state |
+
+### Key implementation detail worth reviewing
+
+In `write.scala`, the `commitIfRequested` helper is shared between `handleStdin` and `handleFlags` (lines 274-289). In `update.scala` the equivalent logic is inlined directly (lines 227-237). This slight asymmetry is intentional: `write.scala` has two code paths that both need to commit, so a helper avoids duplication; `update.scala` has only one write path so inlining is fine. Verify this is the right call.
+
+The commit uses `outputPath / os.up` as the working directory — this is the parent directory of `review-state.json`, not `os.pwd`. Cross-check that `commitFileWithRetry` behaves correctly when the repo root is an ancestor of `outputPath / os.up` rather than equal to it. The existing phase commands all pass `os.pwd` (which is always the repo root), so this is a subtle behavioural difference worth a quick read of `Git.scala:162`.

--- a/project-management/issues/IW-340/review-state.json
+++ b/project-management/issues/IW-340/review-state.json
@@ -13,12 +13,12 @@
       "category": "output"
     }
   ],
-  "last_updated": "2026-04-13T08:57:31.837414571Z",
+  "last_updated": "2026-04-13T11:25:09.848058653Z",
   "status": "tasks_ready",
   "display": {
     "text": "Tasks Ready",
     "type": "success",
-    "subtext": "3 phases identified"
+    "subtext": "1 phase identified"
   },
   "message": "Task breakdown complete. Ready to begin implementation.",
   "activity": "waiting",

--- a/project-management/issues/IW-340/review-state.json
+++ b/project-management/issues/IW-340/review-state.json
@@ -11,16 +11,24 @@
       "label": "Tasks",
       "path": "project-management/issues/IW-340/tasks.md",
       "category": "output"
+    },
+    {
+      "label": "Phase 1 Context",
+      "path": "project-management/issues/IW-340/phase-01-context.md"
+    },
+    {
+      "label": "Phase 1 Tasks",
+      "path": "project-management/issues/IW-340/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-04-13T11:25:09.848058653Z",
-  "status": "tasks_ready",
+  "last_updated": "2026-04-13T11:31:07.605203140Z",
+  "status": "implementing",
   "display": {
-    "text": "Tasks Ready",
-    "type": "success",
-    "subtext": "1 phase identified"
+    "text": "Phase 01: Implementing",
+    "type": "progress",
+    "subtext": "Add --commit flag to review-state commands"
   },
-  "message": "Task breakdown complete. Ready to begin implementation.",
+  "message": "Phase 01 implementation started",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -38,7 +46,23 @@
       "id": "implement",
       "label": "Start Implementation",
       "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Continue",
+      "skill": "wf-implement"
     }
   ],
-  "git_sha": "0bebf3e"
+  "git_sha": "0bebf3e",
+  "phase_checkpoints": {
+    "1": {
+      "context_sha": "context_sha=6634e231193e554943a396e278f659fcb96005a7"
+    }
+  },
+  "badges": [
+    {
+      "label": "In Progress",
+      "type": "info"
+    }
+  ]
 }

--- a/project-management/issues/IW-340/review-state.json
+++ b/project-management/issues/IW-340/review-state.json
@@ -21,11 +21,11 @@
       "path": "project-management/issues/IW-340/phase-01-tasks.md"
     }
   ],
-  "last_updated": "2026-04-13T11:31:07.605203140Z",
-  "status": "implementing",
+  "last_updated": "2026-04-13T12:07:15.517861671Z",
+  "status": "awaiting_review",
   "display": {
-    "text": "Phase 01: Implementing",
-    "type": "progress",
+    "text": "Phase 01: Awaiting Review",
+    "type": "warning",
     "subtext": "Add --commit flag to review-state commands"
   },
   "message": "Phase 01 implementation started",
@@ -51,6 +51,11 @@
       "id": "implement",
       "label": "Continue",
       "skill": "wf-implement"
+    },
+    {
+      "id": "view-pr",
+      "label": "View Pull Request",
+      "skill": "external-link"
     }
   ],
   "git_sha": "0bebf3e",
@@ -63,6 +68,12 @@
     {
       "label": "In Progress",
       "type": "info"
+    },
+    {
+      "label": "Review Needed",
+      "type": "warning"
     }
-  ]
+  ],
+  "needs_attention": true,
+  "pr_url": "https://github.com/iterative-works/iw-cli/pull/341"
 }

--- a/project-management/issues/IW-340/review-state.json
+++ b/project-management/issues/IW-340/review-state.json
@@ -19,16 +19,28 @@
     {
       "label": "Phase 1 Tasks",
       "path": "project-management/issues/IW-340/phase-01-tasks.md"
+    },
+    {
+      "label": "Implementation Log",
+      "path": "project-management/issues/IW-340/implementation-log.md"
+    },
+    {
+      "label": "Release Notes",
+      "path": "project-management/issues/IW-340/release-notes.md"
+    },
+    {
+      "label": "Review Packet",
+      "path": "project-management/issues/IW-340/review-packet.md"
     }
   ],
-  "last_updated": "2026-04-13T12:07:15.517861671Z",
-  "status": "awaiting_review",
+  "last_updated": "2026-04-14T06:34:20.830925748Z",
+  "status": "all_complete",
   "display": {
-    "text": "Phase 01: Awaiting Review",
-    "type": "warning",
+    "text": "Ready for Final Review",
+    "type": "success",
     "subtext": "Add --commit flag to review-state commands"
   },
-  "message": "Phase 01 implementation started",
+  "message": "All phases complete - final PR created",
   "activity": "waiting",
   "workflow_type": "waterfall",
   "available_actions": [
@@ -75,5 +87,5 @@
     }
   ],
   "needs_attention": true,
-  "pr_url": "https://github.com/iterative-works/iw-cli/pull/341"
+  "pr_url": "https://github.com/iterative-works/iw-cli/pull/342"
 }

--- a/project-management/issues/IW-340/review-state.json
+++ b/project-management/issues/IW-340/review-state.json
@@ -1,0 +1,44 @@
+{
+  "version": 2,
+  "issue_id": "IW-340",
+  "artifacts": [
+    {
+      "label": "Analysis",
+      "path": "project-management/issues/IW-340/analysis.md",
+      "category": "input"
+    },
+    {
+      "label": "Tasks",
+      "path": "project-management/issues/IW-340/tasks.md",
+      "category": "output"
+    }
+  ],
+  "last_updated": "2026-04-13T08:57:31.837414571Z",
+  "status": "tasks_ready",
+  "display": {
+    "text": "Tasks Ready",
+    "type": "success",
+    "subtext": "3 phases identified"
+  },
+  "message": "Task breakdown complete. Ready to begin implementation.",
+  "activity": "waiting",
+  "workflow_type": "waterfall",
+  "available_actions": [
+    {
+      "id": "create-tasks",
+      "label": "Generate Tasks",
+      "skill": "wf-create-tasks"
+    },
+    {
+      "id": "implement",
+      "label": "Start Implementation",
+      "skill": "wf-implement"
+    },
+    {
+      "id": "implement",
+      "label": "Start Implementation",
+      "skill": "wf-implement"
+    }
+  ],
+  "git_sha": "0bebf3e"
+}

--- a/project-management/issues/IW-340/tasks.md
+++ b/project-management/issues/IW-340/tasks.md
@@ -6,11 +6,11 @@
 
 ## Phase Index
 
-- [ ] Phase 1: Add --commit flag to review-state commands (Est: 2.5-5h) → `phase-01-context.md`
+- [x] Phase 1: Add --commit flag to review-state commands (Est: 2.5-5h) → `phase-01-context.md`
 
 ## Progress Tracker
 
-**Completed:** 0/1 phases
+**Completed:** 1/1 phases
 **Estimated Total:** 2.5-5 hours
 **Time Spent:** 0 hours
 

--- a/project-management/issues/IW-340/tasks.md
+++ b/project-management/issues/IW-340/tasks.md
@@ -1,0 +1,25 @@
+# Implementation Tasks: Add --commit flag to review-state update command
+
+**Issue:** IW-340
+**Created:** 2026-04-13
+**Status:** 0/3 phases complete (0%)
+
+## Phase Index
+
+- [ ] Phase 1: update.scala --commit flag (Est: 1-2h) → `phase-01-context.md`
+- [ ] Phase 2: write.scala --commit flag (Est: 0.5-1h) → `phase-02-context.md`
+- [ ] Phase 3: E2E tests (Est: 1-2h) → `phase-03-context.md`
+
+## Progress Tracker
+
+**Completed:** 0/3 phases
+**Estimated Total:** 2.5-5 hours
+**Time Spent:** 0 hours
+
+## Notes
+
+- Phase context files generated just-in-time during implementation
+- Use wf-implement to start next phase automatically
+- Estimates are rough and will be refined during implementation
+- All changes are in the presentation layer (command scripts) — no core changes needed
+- Existing `GitAdapter.commitFileWithRetry()` provides the commit infrastructure

--- a/project-management/issues/IW-340/tasks.md
+++ b/project-management/issues/IW-340/tasks.md
@@ -2,17 +2,15 @@
 
 **Issue:** IW-340
 **Created:** 2026-04-13
-**Status:** 0/3 phases complete (0%)
+**Status:** 0/1 phases complete (0%)
 
 ## Phase Index
 
-- [ ] Phase 1: update.scala --commit flag (Est: 1-2h) → `phase-01-context.md`
-- [ ] Phase 2: write.scala --commit flag (Est: 0.5-1h) → `phase-02-context.md`
-- [ ] Phase 3: E2E tests (Est: 1-2h) → `phase-03-context.md`
+- [ ] Phase 1: Add --commit flag to review-state commands (Est: 2.5-5h) → `phase-01-context.md`
 
 ## Progress Tracker
 
-**Completed:** 0/3 phases
+**Completed:** 0/1 phases
 **Estimated Total:** 2.5-5 hours
 **Time Spent:** 0 hours
 
@@ -23,3 +21,4 @@
 - Estimates are rough and will be refined during implementation
 - All changes are in the presentation layer (command scripts) — no core changes needed
 - Existing `GitAdapter.commitFileWithRetry()` provides the commit infrastructure
+- Single phase covers: update.scala, write.scala, and E2E tests (TDD)

--- a/test/review-state.bats
+++ b/test/review-state.bats
@@ -706,3 +706,171 @@ assert d['workflow_type'] == 'waterfall'
     [[ "$output" == *"--workflow-type"* ]]
     [[ "$output" == *"--clear-workflow-type"* ]]
 }
+
+# ============================================================================
+# UPDATE --commit FLAG TESTS
+# ============================================================================
+
+setup_git_repo() {
+    local dir="$1"
+    git -C "$dir" init -q
+    git -C "$dir" config user.email "test@test.com"
+    git -C "$dir" config user.name "Test"
+    # Create an initial commit so HEAD exists
+    git -C "$dir" commit -q --allow-empty -m "initial"
+}
+
+@test "review-state update: --commit stages and commits review-state.json (clean tree after)" {
+    setup_git_repo "$TEST_TMPDIR"
+    local state_file="$TEST_TMPDIR/state.json"
+    echo '{"version":2,"issue_id":"IW-1","artifacts":[],"last_updated":"2026-01-01T12:00:00Z"}' > "$state_file"
+    git -C "$TEST_TMPDIR" add "$state_file"
+    git -C "$TEST_TMPDIR" commit -q -m "add state"
+
+    run "$PROJECT_ROOT/iw" review-state update \
+        --issue-id IW-1 \
+        --status implementing \
+        --input "$state_file" \
+        --commit
+    [ "$status" -eq 0 ]
+
+    # Working tree should be clean (file committed)
+    run git -C "$TEST_TMPDIR" status --porcelain
+    [ "$output" = "" ]
+}
+
+@test "review-state update: --commit message contains issue ID and status" {
+    setup_git_repo "$TEST_TMPDIR"
+    local state_file="$TEST_TMPDIR/state.json"
+    echo '{"version":2,"issue_id":"IW-42","artifacts":[],"last_updated":"2026-01-01T12:00:00Z"}' > "$state_file"
+    git -C "$TEST_TMPDIR" add "$state_file"
+    git -C "$TEST_TMPDIR" commit -q -m "add state"
+
+    run "$PROJECT_ROOT/iw" review-state update \
+        --issue-id IW-42 \
+        --status done \
+        --input "$state_file" \
+        --commit
+    [ "$status" -eq 0 ]
+
+    local msg
+    msg="$(git -C "$TEST_TMPDIR" log -1 --format=%s)"
+    [[ "$msg" == *"IW-42"* ]]
+    [[ "$msg" == *"done"* ]]
+}
+
+@test "review-state update: --commit without --status uses generic commit message" {
+    setup_git_repo "$TEST_TMPDIR"
+    local state_file="$TEST_TMPDIR/state.json"
+    echo '{"version":2,"issue_id":"IW-10","artifacts":[],"last_updated":"2026-01-01T12:00:00Z"}' > "$state_file"
+    git -C "$TEST_TMPDIR" add "$state_file"
+    git -C "$TEST_TMPDIR" commit -q -m "add state"
+
+    run "$PROJECT_ROOT/iw" review-state update \
+        --issue-id IW-10 \
+        --message "hello" \
+        --input "$state_file" \
+        --commit
+    [ "$status" -eq 0 ]
+
+    local msg
+    msg="$(git -C "$TEST_TMPDIR" log -1 --format=%s)"
+    [[ "$msg" == *"IW-10"* ]]
+    [[ "$msg" != *" to "* ]]
+}
+
+@test "review-state update: without --commit, file is written but not committed" {
+    setup_git_repo "$TEST_TMPDIR"
+    local state_file="$TEST_TMPDIR/state.json"
+    echo '{"version":2,"issue_id":"IW-1","artifacts":[],"last_updated":"2026-01-01T12:00:00Z"}' > "$state_file"
+    git -C "$TEST_TMPDIR" add "$state_file"
+    git -C "$TEST_TMPDIR" commit -q -m "add state"
+
+    run "$PROJECT_ROOT/iw" review-state update \
+        --issue-id IW-1 \
+        --status implementing \
+        --input "$state_file"
+    [ "$status" -eq 0 ]
+
+    # File should be modified but not committed
+    run git -C "$TEST_TMPDIR" status --porcelain "$state_file"
+    [[ "$output" != "" ]]
+}
+
+@test "review-state update: --help includes --commit flag" {
+    run "$PROJECT_ROOT/iw" review-state update --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--commit"* ]]
+}
+
+# ============================================================================
+# WRITE --commit FLAG TESTS
+# ============================================================================
+
+@test "review-state write: --commit stages and commits the written file (clean tree after)" {
+    setup_git_repo "$TEST_TMPDIR"
+    local state_file="$TEST_TMPDIR/state.json"
+
+    run "$PROJECT_ROOT/iw" review-state write \
+        --issue-id IW-1 \
+        --status implementing \
+        --output "$state_file" \
+        --commit
+    [ "$status" -eq 0 ]
+
+    # Working tree should be clean
+    run git -C "$TEST_TMPDIR" status --porcelain
+    [ "$output" = "" ]
+}
+
+@test "review-state write: without --commit, file is written but not committed" {
+    setup_git_repo "$TEST_TMPDIR"
+    local state_file="$TEST_TMPDIR/state.json"
+
+    run "$PROJECT_ROOT/iw" review-state write \
+        --issue-id IW-1 \
+        --status implementing \
+        --output "$state_file"
+    [ "$status" -eq 0 ]
+
+    # File should exist but not be committed
+    [ -f "$state_file" ]
+    run git -C "$TEST_TMPDIR" status --porcelain "$state_file"
+    [[ "$output" != "" ]]
+}
+
+@test "review-state write: --from-stdin --commit stages and commits (clean tree after)" {
+    setup_git_repo "$TEST_TMPDIR"
+    local state_file="$TEST_TMPDIR/state.json"
+    local json='{"version":2,"issue_id":"IW-1","artifacts":[],"last_updated":"2026-01-28T12:00:00Z"}'
+
+    run bash -c "echo '$json' | '$PROJECT_ROOT/iw' review-state write --from-stdin --commit --issue-id IW-1 --output '$state_file'"
+    [ "$status" -eq 0 ]
+
+    # Working tree should be clean
+    run git -C "$TEST_TMPDIR" status --porcelain
+    [ "$output" = "" ]
+}
+
+@test "review-state write: --commit message contains issue ID and status" {
+    setup_git_repo "$TEST_TMPDIR"
+    local state_file="$TEST_TMPDIR/state.json"
+
+    run "$PROJECT_ROOT/iw" review-state write \
+        --issue-id IW-55 \
+        --status reviewing \
+        --output "$state_file" \
+        --commit
+    [ "$status" -eq 0 ]
+
+    local msg
+    msg="$(git -C "$TEST_TMPDIR" log -1 --format=%s)"
+    [[ "$msg" == *"IW-55"* ]]
+    [[ "$msg" == *"reviewing"* ]]
+}
+
+@test "review-state write: --help includes --commit flag" {
+    run "$PROJECT_ROOT/iw" review-state write --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--commit"* ]]
+}


### PR DESCRIPTION
## Summary

- Add optional `--commit` flag to `review-state update` and `review-state write` commands
- When present, automatically stages and commits review-state.json after writing using `GitAdapter.commitFileWithRetry()`
- Eliminates "dirty working tree" errors at workflow phase boundaries
- Commit failure is non-fatal (warning printed, exit 0)

## Changes

- `commands/review-state/update.scala` — `--commit` flag with post-write commit logic
- `commands/review-state/write.scala` — `--commit` flag with shared `commitIfRequested` helper for both `handleFlags` and `handleStdin` paths
- `test/review-state.bats` — 10 new E2E tests (update: 5, write: 5)

## Test plan

- [x] 10 new `--commit` flag E2E tests pass
- [x] All 61 review-state E2E tests pass
- [x] Core compiles with `-Werror`
- [x] All 35 commands compile
- [x] Unit tests pass

## Release Notes (CZ)

Příkazy `review-state update` a `review-state write` nově podporují volitelný přepínač `--commit`. Když je tento přepínač uveden, nástroj po zápisu souboru review-state.json automaticky provede jeho uložení do gitu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)