### PR TITLE
Fix parent project registration for GitHub/GitLab projects

### DIFF
--- a/commands/start.scala
+++ b/commands/start.scala
@@ -116,7 +116,7 @@ def createWorktreeForIssue(
     config.projectName,
     currentDir.toString,
     config.trackerType.toString,
-    config.team,
+    config.teamIdentifier,
     trackerUrl
   ) match
     case Left(error) =>


### PR DESCRIPTION
## Summary
- `./iw start <id>` warned `Failed to register parent project with dashboard: Server returned 400: Team cannot be empty` on GitHub projects because `config.team` is empty for GitHub/GitLab (those use `repository` instead).
- Switch to `config.teamIdentifier`, which falls back to `repository` for GitHub/GitLab — same pattern already used by `register.scala`.

## Test plan
- [x] Unit tests pass (`./iw ./test unit`)
- [x] All 35 commands compile
- [ ] Manual: `./iw start <id>` on this repo no longer prints the "Team cannot be empty" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)