### PR TITLE
Fix bloop daemon leak in BATS tests

### DIFF
--- a/test/helpers/bloop-cleanup.bash
+++ b/test/helpers/bloop-cleanup.bash
@@ -1,0 +1,43 @@
+# PURPOSE: Shared helper to stop orphan bloop daemons spawned by scala-cli during tests
+# PURPOSE: Source this from .bats files that set XDG_DATA_HOME to a temp directory
+
+# Kill any bloop daemon whose XDG_DATA_HOME points at our test directory.
+# Must be called BEFORE rm -rf "$TEST_DIR" so /proc/$pid/environ is still readable.
+stop_test_bloop() {
+    local test_xdg="${XDG_DATA_HOME:-}"
+    [ -n "$test_xdg" ] || return 0
+
+    local pids=""
+    for pid_dir in /proc/[0-9]*/environ; do
+        local pid="${pid_dir#/proc/}"
+        pid="${pid%/environ}"
+        # Read environ (NUL-delimited); match our XDG_DATA_HOME exactly
+        if tr '\0' '\n' < "$pid_dir" 2>/dev/null \
+                | grep -qx "XDG_DATA_HOME=${test_xdg}"; then
+            # Confirm it's actually a bloop daemon, not some unrelated process
+            if grep -q "bloop-frontend" "/proc/${pid}/cmdline" 2>/dev/null; then
+                pids="$pids $pid"
+            fi
+        fi
+    done
+
+    [ -n "$pids" ] || return 0
+
+    # Graceful TERM first
+    kill -TERM $pids 2>/dev/null || true
+    # Brief wait for JVM to exit
+    local retries=10
+    while [ "$retries" -gt 0 ]; do
+        local still_alive=""
+        for pid in $pids; do
+            kill -0 "$pid" 2>/dev/null && still_alive="$still_alive $pid"
+        done
+        [ -n "$still_alive" ] || return 0
+        pids="$still_alive"
+        sleep 0.1
+        retries=$((retries - 1))
+    done
+
+    # Force kill survivors
+    kill -KILL $pids 2>/dev/null || true
+}

--- a/test/plugin-commands-describe.bats
+++ b/test/plugin-commands-describe.bats
@@ -2,6 +2,8 @@
 # PURPOSE: E2E tests for plugin command description with --describe
 # PURPOSE: Verifies --describe works for plugin/command syntax with source attribution
 
+load helpers/bloop-cleanup
+
 setup() {
     # Disable dashboard server communication during tests
     export IW_SERVER_DISABLED=1
@@ -62,6 +64,7 @@ EOF
 }
 
 teardown() {
+    stop_test_bloop
     cd /
     rm -rf "$TEST_DIR"
 }

--- a/test/plugin-commands-execute.bats
+++ b/test/plugin-commands-execute.bats
@@ -2,6 +2,8 @@
 # PURPOSE: E2E tests for plugin command execution with <plugin>/<command> syntax
 # PURPOSE: Verifies plugin commands are found, compiled, and run with correct classpath
 
+load helpers/bloop-cleanup
+
 setup() {
     # Disable dashboard server communication during tests
     export IW_SERVER_DISABLED=1
@@ -64,6 +66,7 @@ EOF
 }
 
 teardown() {
+    stop_test_bloop
     cd /
     rm -rf "$TEST_DIR"
 }

--- a/test/plugin-commands-list.bats
+++ b/test/plugin-commands-list.bats
@@ -2,6 +2,8 @@
 # PURPOSE: E2E tests for plugin command listing in iw --list output
 # PURPOSE: Verifies plugin commands are displayed with correct format and filtering
 
+load helpers/bloop-cleanup
+
 setup() {
     # Disable dashboard server communication during tests
     export IW_SERVER_DISABLED=1
@@ -57,6 +59,7 @@ EOF
 }
 
 teardown() {
+    stop_test_bloop
     cd /
     rm -rf "$TEST_DIR"
 }

--- a/test/plugin-discovery.bats
+++ b/test/plugin-discovery.bats
@@ -2,6 +2,8 @@
 # PURPOSE: E2E tests for plugin directory discovery in iw-run
 # PURPOSE: Verifies plugins are found via XDG_DATA_HOME and IW_PLUGIN_DIRS
 
+load helpers/bloop-cleanup
+
 setup() {
     # Disable dashboard server communication during tests
     export IW_SERVER_DISABLED=1
@@ -49,6 +51,7 @@ EOF
 }
 
 teardown() {
+    stop_test_bloop
     cd /
     rm -rf "$TEST_DIR"
 }

--- a/test/plugin-hooks.bats
+++ b/test/plugin-hooks.bats
@@ -2,6 +2,8 @@
 # PURPOSE: Tests for plugin hook discovery and class extraction in iw-run
 # PURPOSE: Verifies hooks from plugin directories and project commands are discovered
 
+load helpers/bloop-cleanup
+
 setup() {
     export IW_SERVER_DISABLED=1
 
@@ -64,6 +66,7 @@ EOF
 }
 
 teardown() {
+    stop_test_bloop
     cd /
     rm -rf "$TEST_DIR"
 }

--- a/test/version-check.bats
+++ b/test/version-check.bats
@@ -2,6 +2,8 @@
 # PURPOSE: Tests for version file reading and version requirement checking in iw-run
 # PURPOSE: Covers read_iw_version(), compare_versions(), and check_version_requirement()
 
+load helpers/bloop-cleanup
+
 setup() {
     export IW_SERVER_DISABLED=1
 
@@ -39,6 +41,7 @@ setup() {
 }
 
 teardown() {
+    stop_test_bloop
     cd /
     rm -rf "$TEST_DIR"
 }


### PR DESCRIPTION
## Summary
- BATS tests that isolate `XDG_DATA_HOME` to a temp dir were orphaning bloop daemons (~1-2 GB each) that accumulated indefinitely across test runs
- Added `test/helpers/bloop-cleanup.bash` with `stop_test_bloop()` that kills matching bloop daemons via `/proc/*/environ` before teardown removes the temp dir
- Applied to all 6 `.bats` files that set `XDG_DATA_HOME`

## Test plan
- [x] All 6 affected test files pass
- [x] Bloop daemon count stays stable before/after running the affected tests
- [x] Pre-commit and pre-push hooks pass

Follow-up: #357 (share a single bloop daemon per `.bats` file for speed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)