### PR TITLE
Fix phase-merge and batch-implement for projects without CI

### DIFF
--- a/commands/batch-implement.scala
+++ b/commands/batch-implement.scala
@@ -94,14 +94,42 @@ import java.time.format.DateTimeFormatter
     sys.exit(1)
 
   // --- Pre-flight: clean working tree ---
+  //
+  // A previous interrupted batch-implement run may have left the workflow's
+  // own state files dirty (e.g. review-state.json updated but not committed
+  // because phase-merge failed). Those are ours to clean up. User code
+  // changes, however, must be handled manually.
 
-  val isDirty =
-    CommandHelpers.exitOnError(GitAdapter.hasUncommittedChanges(cwd))
-  if isDirty then
-    Output.error(
-      "Working tree has uncommitted changes. Please commit or stash them before running batch-implement."
+  val stagingCheck = CommandHelpers.exitOnError(GitAdapter.getStagingCheck(cwd))
+  val dirtyPaths =
+    stagingCheck.stagedFiles ++ stagingCheck.unstagedFiles ++ stagingCheck.untrackedFiles
+  if dirtyPaths.nonEmpty then
+    val (stateOwned, userOwned) =
+      WorkflowStatePaths.partition(dirtyPaths, issueId.value)
+    if userOwned.nonEmpty then
+      Output.error(
+        "Working tree has uncommitted changes outside the workflow state directory:"
+      )
+      userOwned.foreach(p => Output.error(s"  $p"))
+      Output.error(
+        "Please commit or stash them before running batch-implement."
+      )
+      sys.exit(1)
+    // Only state files dirty → commit them ourselves so the workflow starts
+    // from a clean tree.
+    Output.info(
+      s"Committing ${stateOwned.size} stale workflow state file(s) from a previous run..."
     )
-    sys.exit(1)
+    CommandHelpers.exitOnError(GitAdapter.stageAll(cwd))
+    GitAdapter.commit(
+      s"chore(${issueId.value}): recover workflow state from interrupted run",
+      cwd
+    ) match
+      case Right(sha) =>
+        Output.info(s"Committed recovered state as $sha")
+      case Left(err) =>
+        Output.error(s"Failed to commit recovered state: $err")
+        sys.exit(1)
 
   // --- Workflow code resolution ---
 

--- a/core/adapters/GitHubClient.scala
+++ b/core/adapters/GitHubClient.scala
@@ -797,6 +797,11 @@ object GitHubClient:
         Left(s"gh CLI error: $msg")
       case Right(_) =>
         execCommand("gh", buildCheckStatusesCommand(prNumber, repository)) match
+          case Left(error) if error.contains("no checks reported") =>
+            // `gh pr checks` exits non-zero when the branch has no CI
+            // configured; surface that as an empty list so callers can
+            // treat it as "proceed".
+            Right(Nil)
           case Left(error) => Left(s"Failed to fetch check statuses: $error")
           case Right(json) => parseGhChecksJson(json)
 

--- a/core/model/WorkflowStatePaths.scala
+++ b/core/model/WorkflowStatePaths.scala
@@ -1,0 +1,29 @@
+// PURPOSE: Distinguishes workflow-owned state paths from user code when checking for uncommitted changes
+// PURPOSE: Lets batch-implement re-enter after an interrupted run without being blocked by its own state writes
+
+package iw.core.model
+
+/** Pure helper for classifying dirty working-tree paths against the issue's
+  * workflow state directory.
+  */
+object WorkflowStatePaths:
+
+  /** Directory (relative to repo root) where the workflow writes its state
+    * files for a given issue.
+    */
+  def stateDir(issueId: String): String =
+    s"project-management/issues/$issueId/"
+
+  /** Split a list of repo-relative paths into (stateOwned, userOwned).
+    *
+    * Paths under `project-management/issues/<issueId>/` are considered
+    * state-owned — the workflow writes them (review-state.json, phase files,
+    * etc.) and has permission to auto-commit them. Everything else is user code
+    * that must be committed manually before the workflow runs.
+    */
+  def partition(
+      paths: List[String],
+      issueId: String
+  ): (List[String], List[String]) =
+    val prefix = stateDir(issueId)
+    paths.partition(_.startsWith(prefix))

--- a/core/test/GitHubClientTest.scala
+++ b/core/test/GitHubClientTest.scala
@@ -1137,6 +1137,26 @@ class GitHubClientTest extends munit.FunSuite:
 
     assertEquals(result, Right(Nil))
 
+  test(
+    "fetchCheckStatuses returns Right(Nil) when gh reports 'no checks reported'"
+  ):
+    // `gh pr checks` exits non-zero with this message when a branch has no CI
+    // configured. Treat it as an empty list rather than an error.
+    val mockExec: (String, Array[String]) => Either[String, String] =
+      (cmd, args) =>
+        if args.contains("auth") && args.contains("status") then
+          Right("Logged in")
+        else Left("no checks reported on the 'IW-344-phase-01' branch")
+
+    val result = GitHubClient.fetchCheckStatuses(
+      prNumber = 42,
+      repository = "owner/repo",
+      isCommandAvailable = _ => true,
+      execCommand = mockExec
+    )
+
+    assertEquals(result, Right(Nil))
+
   // ========== JSON Parsing Tests (via fetchCheckStatuses) ==========
 
   private def fetchWithJson(

--- a/core/test/WorkflowStatePathsTest.scala
+++ b/core/test/WorkflowStatePathsTest.scala
@@ -1,0 +1,64 @@
+// PURPOSE: Unit tests for WorkflowStatePaths model
+// PURPOSE: Verifies correct partitioning of dirty paths into state-owned and user-owned
+
+package iw.core.model
+
+import munit.FunSuite
+
+class WorkflowStatePathsTest extends FunSuite:
+
+  test("partition: only state files → all state, no user"):
+    val paths = List(
+      "project-management/issues/IW-344/review-state.json",
+      "project-management/issues/IW-344/phase-01-context.md"
+    )
+    val (state, user) = WorkflowStatePaths.partition(paths, "IW-344")
+    assertEquals(state, paths)
+    assertEquals(user, Nil)
+
+  test("partition: only user files → all user, no state"):
+    val paths = List(
+      "src/Main.scala",
+      "core/adapters/Git.scala"
+    )
+    val (state, user) = WorkflowStatePaths.partition(paths, "IW-344")
+    assertEquals(state, Nil)
+    assertEquals(user, paths)
+
+  test("partition: mixed → correctly split"):
+    val paths = List(
+      "project-management/issues/IW-344/review-state.json",
+      "src/Main.scala",
+      "project-management/issues/IW-344/phase-02-tasks.md",
+      "iw-run"
+    )
+    val (state, user) = WorkflowStatePaths.partition(paths, "IW-344")
+    assertEquals(
+      state,
+      List(
+        "project-management/issues/IW-344/review-state.json",
+        "project-management/issues/IW-344/phase-02-tasks.md"
+      )
+    )
+    assertEquals(user, List("src/Main.scala", "iw-run"))
+
+  test("partition: other issue's state files count as user"):
+    // If the tree has dirt under a different issue's state dir, that's not
+    // ours to auto-commit — treat as user-owned so the user decides.
+    val paths = List(
+      "project-management/issues/IW-999/review-state.json"
+    )
+    val (state, user) = WorkflowStatePaths.partition(paths, "IW-344")
+    assertEquals(state, Nil)
+    assertEquals(user, paths)
+
+  test("partition: empty input → empty partitions"):
+    val (state, user) = WorkflowStatePaths.partition(Nil, "IW-344")
+    assertEquals(state, Nil)
+    assertEquals(user, Nil)
+
+  test("stateDir: produces trailing-slash prefix"):
+    assertEquals(
+      WorkflowStatePaths.stateDir("IW-344"),
+      "project-management/issues/IW-344/"
+    )


### PR DESCRIPTION
## Summary
- `GitHubClient.fetchCheckStatuses`: treat gh's "no checks reported on the '<branch>' branch" error as `Right(Nil)` so `phase-merge` reaches the existing `NoChecksFound → proceed-with-merge` path
- `batch-implement` pre-flight: partition dirty paths into workflow state (under `project-management/issues/<id>/`) vs user code via the new pure `WorkflowStatePaths.partition` helper; auto-commit state-only dirt so re-entry works after an interrupted run, and only block on user-owned changes

## Motivation
Reported by Michal: a batch-implement run on `IW-344` committed a PR, `phase-merge` failed because the project has no CI (gh exits non-zero with "no checks reported"), the run left `review-state.json` modified, and then re-running batch-implement was blocked by its own state file.

## Test plan
- [x] Added `fetchCheckStatuses returns Right(Nil) when gh reports 'no checks reported'` — failing before the fix, passing after
- [x] Added `WorkflowStatePathsTest` covering mixed paths, other-issue state paths, empty input
- [x] Pre-commit format check + core compilation with `-Werror` pass
- [x] Pre-push unit tests + command compilation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)