### PR TITLE
fix(phase): Mark phase complete in tasks.md index on merge

### DIFF
--- a/core/commands/PhaseAdvance.scala
+++ b/core/commands/PhaseAdvance.scala
@@ -186,6 +186,7 @@ object PhaseAdvance:
         CommandResult.error
       case Right(headSha) =>
         maybeUpdateReviewState(r, env)
+        PhaseIndexSync.markPhaseComplete(env, r.issueId, r.phaseNumber)
         env.console.out(
           PhaseOutput
             .AdvanceOutput(

--- a/core/commands/PhaseIndexSync.scala
+++ b/core/commands/PhaseIndexSync.scala
@@ -1,0 +1,56 @@
+// PURPOSE: Marks a merged phase complete in the issue's tasks.md index and commits it
+// PURPOSE: Shared by phase-advance and phase-merge so the index checkbox tracks the phase_merged transition
+
+package iw.core.commands
+
+import iw.core.model.{BatchImplement, IssueId, PhaseNumber}
+
+/** Catch-up that flips the `- [ ] Phase N:` checkbox in the issue's tasks.md
+  * index to `- [x]` once a phase has merged.
+  *
+  * Both `phase-merge` (happy path) and `phase-advance` (external-merge
+  * catch-up) transition review-state to `phase_merged`; this keeps the index in
+  * lockstep so the same fact is not recorded in two places that can drift
+  * apart.
+  *
+  * Best-effort: a missing index, an absent phase line, or an already-checked
+  * box are non-fatal — the merge has still happened, so we warn (never fail).
+  */
+object PhaseIndexSync:
+
+  def markPhaseComplete(
+      env: CommandEnv,
+      issueId: IssueId,
+      phaseNumber: PhaseNumber
+  ): Unit =
+    val tasksPath =
+      env.cwd / "project-management" / "issues" / issueId.value / "tasks.md"
+    if env.fs.exists(tasksPath) then
+      env.fs.read(tasksPath) match
+        case Left(err) =>
+          warn(env, s"Failed to read tasks.md index: $err")
+        case Right(content) =>
+          BatchImplement.markPhaseComplete(content, phaseNumber.toInt) match
+            case Left(reason) =>
+              warn(
+                env,
+                s"Could not mark phase ${phaseNumber.value} in tasks.md index: $reason"
+              )
+            case Right(updated) =>
+              env.fs.write(tasksPath, updated) match
+                case Left(err) =>
+                  warn(env, s"Failed to update tasks.md index: $err")
+                case Right(()) =>
+                  env.git
+                    .commitFileWithRetry(
+                      tasksPath,
+                      s"chore(${issueId.value}): mark phase ${phaseNumber.value} complete in tasks.md",
+                      env.cwd
+                    )
+                    .left
+                    .foreach(err =>
+                      warn(env, s"Failed to commit tasks.md index update: $err")
+                    )
+
+  private def warn(env: CommandEnv, message: String): Unit =
+    env.console.err(s"Error: Warning: $message")

--- a/core/commands/PhaseMerge.scala
+++ b/core/commands/PhaseMerge.scala
@@ -365,6 +365,7 @@ object PhaseMerge:
                     s"Error: Warning: Failed to commit review-state update: $err"
                   )
                 )
+            PhaseIndexSync.markPhaseComplete(env, r.issueId, r.phaseNumber)
             env.console.out(
               PhaseOutput
                 .MergeOutput(

--- a/core/test/PhaseAdvanceHarnessTest.scala
+++ b/core/test/PhaseAdvanceHarnessTest.scala
@@ -209,6 +209,55 @@ class PhaseAdvanceHarnessTest extends munit.FunSuite:
     )
   }
 
+  test("tasks.md index present: marks merged phase complete and commits it") {
+    val env = envOnPhaseBranch()
+    env.process.scriptResponse(
+      Seq("gh", "pr", "list"),
+      ProcessResult(0, """[{"url":"https://example.com/pr"}]""", "")
+    )
+    val reviewStatePath =
+      cwd / "project-management" / "issues" / "TEST-100" / "review-state.json"
+    env.fs.put(
+      reviewStatePath,
+      """{
+        |  "version": 2,
+        |  "issue_id": "TEST-100",
+        |  "status": "awaiting_review",
+        |  "artifacts": [],
+        |  "last_updated": "2026-01-01T12:00:00Z"
+        |}""".stripMargin
+    )
+    val tasksPath =
+      cwd / "project-management" / "issues" / "TEST-100" / "tasks.md"
+    env.fs.put(
+      tasksPath,
+      """# Tasks
+        |
+        |## Phase Index
+        |
+        |- [ ] Phase 1: Foundations
+        |- [ ] Phase 2: Feature
+        |""".stripMargin
+    )
+
+    val result = PhaseAdvance.run(Seq.empty, env)
+
+    assertEquals(result.exitCode, 0)
+    val updatedTasks = env.fs.get(tasksPath).getOrElse("")
+    assert(
+      updatedTasks.contains("- [x] Phase 1: Foundations"),
+      s"expected Phase 1 checked, got: $updatedTasks"
+    )
+    assert(
+      updatedTasks.contains("- [ ] Phase 2: Feature"),
+      "Phase 2 must remain unchecked"
+    )
+    assert(
+      env.git.committedMessages.exists(_.contains("tasks.md")),
+      s"expected a tasks.md commit, got: ${env.git.committedMessages}"
+    )
+  }
+
   test("review-state.json absent: no commit, just print JSON") {
     val env = envOnPhaseBranch()
     env.process.scriptResponse(

--- a/core/test/PhaseMergeHarnessTest.scala
+++ b/core/test/PhaseMergeHarnessTest.scala
@@ -90,6 +90,36 @@ class PhaseMergeHarnessTest extends munit.FunSuite:
     assert(updatedState.contains("phase_merged"))
   }
 
+  test("tasks.md index present: merge marks phase complete and commits it") {
+    val env = envOnPhaseBranch()
+    env.tracker.setCheckStatuses(Right(List(passingCheck)))
+    val tasksPath =
+      cwd / "project-management" / "issues" / "TEST-100" / "tasks.md"
+    env.fs.put(
+      tasksPath,
+      """# Tasks
+        |
+        |## Phase Index
+        |
+        |- [ ] Phase 1: Foundations
+        |- [ ] Phase 2: Feature
+        |""".stripMargin
+    )
+
+    val result = PhaseMerge.run(Seq.empty, env)
+
+    assertEquals(result.exitCode, 0)
+    val updatedTasks = env.fs.get(tasksPath).getOrElse("")
+    assert(
+      updatedTasks.contains("- [x] Phase 1: Foundations"),
+      s"expected Phase 1 checked, got: $updatedTasks"
+    )
+    assert(
+      updatedTasks.contains("- [ ] Phase 2: Feature"),
+      "Phase 2 must remain unchecked"
+    )
+  }
+
   test("not on phase branch: exit 1") {
     val env = envOnPhaseBranch()
     env.git.setCurrentBranch("TEST-100")


### PR DESCRIPTION
## Summary

`phase-merge` and `phase-advance` both transition review-state to `phase_merged` but left the `tasks.md` Phase Index checkbox unchecked, so the index drifted from reality on every interactive/external merge — only the batch driver flipped it.

Tie the checkbox to the `phase_merged` transition via a shared `PhaseIndexSync` helper (reusing the existing `BatchImplement.markPhaseComplete`) so the same fact is recorded once and fires on every merge path. Best-effort: a missing index, absent phase line, or already-checked box warns rather than failing the merge.

## What changed

- New `core/commands/PhaseIndexSync.scala` — single call site, delegates to existing `BatchImplement.markPhaseComplete`.
- `PhaseMerge.scala` + `PhaseAdvance.scala` — wired to call it on the `phase_merged` write.
- Harness tests added in `PhaseMergeHarnessTest.scala` (1 new scenario) and `PhaseAdvanceHarnessTest.scala` (3 new scenarios).

## Test plan

- [x] `./mill core.test` — green locally (4 new harness scenarios)
- [x] Pre-push hook (scalafmt + scalafix + 32-command compile + unit tests) green
- [ ] CI status checks pass on this PR