### PR TITLE
chore: Split release.sh into release-prepare and release-publish

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,45 +10,65 @@ Each release consists of:
 
 ## Creating a Release
 
-### 1. Update Version
-
-Decide on the version number (e.g., `0.1.0`) following semantic versioning.
-
-### 2. Package the Release
-
-Prerequisites for running `package-release.sh` locally:
+Prerequisites for any release work locally:
 - Mill (the `./mill` wrapper in the repo root)
 - Node 20+ with Corepack enabled (`corepack enable`)
 - Yarn 4 (managed via Corepack)
 - `WEBAWESOME_NPM_TOKEN` exported in your environment (Web Awesome Pro npm registry credential)
+- GitHub CLI (`gh`) authenticated against `iterative-works/iw-cli`
 
-Run the packaging script:
+The release flow is split into two scripts so the version-bump goes
+through `main`'s required PR review and the resulting tag points at the
+merged bump commit, not at whatever `main` happened to be earlier.
+
+### 1. Open the version-bump PR
+
+From a clean `main`, run:
 
 ```bash
-WEBAWESOME_NPM_TOKEN=<your-token> scripts/package-release.sh 0.1.0
+scripts/release-prepare.sh 0.6.3
 ```
 
-This creates:
-- `release/iw-cli-0.1.0.tar.gz` - Contains iw-run, iw-bootstrap, commands, build/iw-core.jar, build/iw-dashboard.jar, and core/project.scala (deps manifest)
+This creates `chore/bump-version-0.6.3`, writes the new `VERSION`,
+commits, pushes, and opens a PR against `main`. Review and merge the PR
+the same way as any other change.
 
-The tarball's `build/` directory holds two pre-built jars produced by Mill:
-- `build/iw-core.jar` — compiled core library (model, adapters, output)
-- `build/iw-dashboard.jar` — dashboard server assembly (includes frontend assets)
+### 2. Publish the release
 
-### 3. Test the Release
-
-Before publishing, test the release package:
+After the PR is merged, sync `main` and run:
 
 ```bash
-# Extract to test directory
+git checkout main && git pull
+scripts/release-publish.sh 0.6.3
+```
+
+This packages the tarball + `iw-bootstrap`, creates the `v0.6.3`
+GitHub release pinned to the current `main` HEAD, and updates the
+rolling `vlatest` release.
+
+### 3. Package only (no publish)
+
+For local testing you can run the packaging step on its own — it does
+not touch git or the GitHub API:
+
+```bash
+WEBAWESOME_NPM_TOKEN=<your-token> scripts/package-release.sh 0.6.3
+```
+
+This produces `release/iw-cli-0.6.3.tar.gz` containing `iw-run`,
+`iw-bootstrap`, `commands/`, `build/iw-core.jar`,
+`build/iw-dashboard.jar`, and `core/project.scala` (deps manifest).
+
+### 4. Test the release tarball
+
+Before publishing (or to validate a published tarball) extract and
+exercise it:
+
+```bash
 mkdir -p /tmp/iw-test
-tar -xzf release/iw-cli-0.1.0.tar.gz -C /tmp/iw-test
-
-# Test bootstrap
-cd /tmp/iw-test/iw-cli-0.1.0
+tar -xzf release/iw-cli-0.6.3.tar.gz -C /tmp/iw-test
+cd /tmp/iw-test/iw-cli-0.6.3
 ./iw-run --bootstrap
-
-# Test commands
 ./iw-run --list
 ```
 
@@ -57,22 +77,6 @@ Or run the automated tests:
 ```bash
 bats test/bootstrap.bats
 ```
-
-### 4. Create GitHub Release
-
-1. Create a new tag:
-   ```bash
-   git tag -a v0.1.0 -m "Release 0.1.0"
-   git push origin v0.1.0
-   ```
-
-2. Create a GitHub release:
-   - Go to https://github.com/iterative-works/iw-cli/releases/new
-   - Select the tag (v0.1.0)
-   - Add release notes
-   - Upload artifacts:
-     - `release/iw-cli-0.1.0.tar.gz`
-     - `iw-bootstrap`
 
 ### 5. Verify Download
 
@@ -94,11 +98,10 @@ echo 'version = "0.1.0"' > .iw/config.conf
 ## Release Checklist
 
 - [ ] All tests pass (unit and integration)
-- [ ] Version number updated in release script
-- [ ] Release tarball created and tested
-- [ ] Bootstrap script works with new release
-- [ ] Git tag created and pushed
-- [ ] GitHub release created with artifacts
+- [ ] `scripts/release-prepare.sh <version>` PR opened, reviewed, merged
+- [ ] `scripts/release-publish.sh <version>` succeeded on `main`
+- [ ] Versioned GitHub release contains tarball + `iw-bootstrap`
+- [ ] `vlatest` release updated
 - [ ] Download from GitHub works correctly
 - [ ] Offline operation verified after bootstrap
 

--- a/scripts/release-prepare.sh
+++ b/scripts/release-prepare.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# PURPOSE: Open a version-bump PR for an iw-cli release
+# PURPOSE: Updates VERSION on a release branch, pushes, and opens the PR for review
+#
+# Usage: scripts/release-prepare.sh <version>
+# Example: scripts/release-prepare.sh 0.6.3
+#
+# After the PR is merged, run scripts/release-publish.sh <version> to
+# package the tarball, create the GitHub release pinned to the merged
+# commit, and update the 'vlatest' pointer.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR/.."
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <version>" >&2
+    echo "Example: $0 0.6.3" >&2
+    exit 1
+fi
+
+VERSION="$1"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be in format X.Y.Z (e.g., 0.6.3)" >&2
+    exit 1
+fi
+
+if ! command -v gh &> /dev/null; then
+    echo "Error: GitHub CLI (gh) not found. Please install it first." >&2
+    exit 1
+fi
+
+if ! gh auth status &> /dev/null; then
+    echo "Error: Not logged in to GitHub CLI. Run 'gh auth login' first." >&2
+    exit 1
+fi
+
+cd "$PROJECT_ROOT"
+
+# Refuse to operate on a dirty tree; the bump commit must be the only change.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: Working tree has uncommitted changes. Commit or stash before running." >&2
+    git status --short >&2
+    exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "Error: release-prepare must be run from 'main' (currently on '$CURRENT_BRANCH')." >&2
+    exit 1
+fi
+
+echo "=== Preparing iw-cli release v$VERSION ==="
+echo ""
+
+echo "Step 1: Syncing main with origin..."
+git fetch origin
+git pull --ff-only origin main
+
+VERSION_FILE="$PROJECT_ROOT/VERSION"
+CURRENT_VERSION="$(tr -d '[:space:]' < "$VERSION_FILE")"
+if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+    echo "Error: VERSION already at $VERSION on main; nothing to prepare." >&2
+    exit 1
+fi
+echo "  Bumping VERSION: $CURRENT_VERSION -> $VERSION"
+
+BRANCH="chore/bump-version-$VERSION"
+echo ""
+echo "Step 2: Creating branch $BRANCH..."
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    echo "Error: Local branch $BRANCH already exists. Delete it or pick a different version." >&2
+    exit 1
+fi
+if git ls-remote --exit-code --heads origin "$BRANCH" &> /dev/null; then
+    echo "Error: Remote branch $BRANCH already exists on origin. Delete it or pick a different version." >&2
+    exit 1
+fi
+git checkout -b "$BRANCH"
+
+echo ""
+echo "Step 3: Writing VERSION and committing..."
+echo "$VERSION" > "$VERSION_FILE"
+git add "$VERSION_FILE"
+git commit -m "chore: Bump version to $VERSION"
+
+echo ""
+echo "Step 4: Pushing branch to origin..."
+git push -u origin "$BRANCH"
+
+echo ""
+echo "Step 5: Opening PR..."
+PR_URL="$(gh pr create \
+    --base main \
+    --head "$BRANCH" \
+    --title "chore: Bump version to $VERSION" \
+    --body "Bumps VERSION to $VERSION ahead of the v$VERSION release.
+
+After merging, run \`scripts/release-publish.sh $VERSION\` from \`main\` to package the tarball, create the v$VERSION GitHub release pinned to the merged commit, and update the \`vlatest\` pointer.")"
+
+echo ""
+echo "=== Release v$VERSION prepared ==="
+echo ""
+echo "  PR: $PR_URL"
+echo ""
+echo "Next steps:"
+echo "  1. Merge the PR above."
+echo "  2. git checkout main && git pull"
+echo "  3. scripts/release-publish.sh $VERSION"

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# PURPOSE: Create a new iw-cli release
-# PURPOSE: Packages tarball, creates GitHub release, and updates 'latest'
+# PURPOSE: Package and publish an iw-cli release after the version-bump PR merged
+# PURPOSE: Creates the v<version> tag pinned to the current main HEAD and updates vlatest
 #
-# Usage: scripts/release.sh <version>
-# Example: scripts/release.sh 0.2.0
+# Usage: scripts/release-publish.sh <version>
+# Example: scripts/release-publish.sh 0.6.3
+#
+# Run AFTER scripts/release-prepare.sh <version> has been opened and merged.
+# Requires VERSION on main to match <version>; refuses to run otherwise.
 
 set -euo pipefail
 
@@ -11,48 +14,70 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR/.."
 RELEASE_DIR="$PROJECT_ROOT/release"
 
-# Validate version argument
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <version>" >&2
-    echo "Example: $0 0.2.0" >&2
+    echo "Example: $0 0.6.3" >&2
     exit 1
 fi
 
 VERSION="$1"
 
-# Validate version format (semver-like)
 if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: Version must be in format X.Y.Z (e.g., 0.2.0)" >&2
+    echo "Error: Version must be in format X.Y.Z (e.g., 0.6.3)" >&2
     exit 1
 fi
 
-# Check if gh CLI is available
 if ! command -v gh &> /dev/null; then
     echo "Error: GitHub CLI (gh) not found. Please install it first." >&2
     exit 1
 fi
 
-# Check if logged in to gh
 if ! gh auth status &> /dev/null; then
     echo "Error: Not logged in to GitHub CLI. Run 'gh auth login' first." >&2
     exit 1
 fi
 
-echo "=== Creating iw-cli release v$VERSION ==="
+cd "$PROJECT_ROOT"
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: Working tree has uncommitted changes. Commit or stash before running." >&2
+    git status --short >&2
+    exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "Error: release-publish must be run from 'main' (currently on '$CURRENT_BRANCH')." >&2
+    exit 1
+fi
+
+echo "=== Publishing iw-cli release v$VERSION ==="
 echo ""
 
-# Step 1: Update VERSION file (single source of truth, read at runtime by version.scala)
-VERSION_FILE="$PROJECT_ROOT/VERSION"
-echo "Step 1: Updating $VERSION_FILE..."
-echo "$VERSION" > "$VERSION_FILE"
-echo "  Version updated to $VERSION"
+echo "Step 1: Syncing main with origin..."
+git fetch origin
+git pull --ff-only origin main
 
-# Step 2: Package the release
+VERSION_FILE="$PROJECT_ROOT/VERSION"
+ON_DISK_VERSION="$(tr -d '[:space:]' < "$VERSION_FILE")"
+if [ "$ON_DISK_VERSION" != "$VERSION" ]; then
+    echo "Error: VERSION on main is $ON_DISK_VERSION, not $VERSION." >&2
+    echo "       Run scripts/release-prepare.sh $VERSION and merge the PR first." >&2
+    exit 1
+fi
+
+MAIN_SHA="$(git rev-parse HEAD)"
+echo "  main HEAD: $MAIN_SHA"
+
+if gh release view "v$VERSION" &> /dev/null; then
+    echo "Error: GitHub release v$VERSION already exists. Delete it first if you intend to recreate." >&2
+    exit 1
+fi
+
 echo ""
 echo "Step 2: Packaging release..."
 "$SCRIPT_DIR/package-release.sh" "$VERSION"
 
-# Step 3: Create GitHub release
 TARBALL="$RELEASE_DIR/iw-cli-${VERSION}.tar.gz"
 if [ ! -f "$TARBALL" ]; then
     echo "Error: Tarball not found: $TARBALL" >&2
@@ -66,8 +91,9 @@ if [ ! -f "$BOOTSTRAP" ]; then
 fi
 
 echo ""
-echo "Step 3: Creating GitHub release v$VERSION..."
+echo "Step 3: Creating GitHub release v$VERSION pinned to $MAIN_SHA..."
 gh release create "v$VERSION" "$TARBALL" "$BOOTSTRAP" \
+    --target "$MAIN_SHA" \
     --title "iw-cli v$VERSION" \
     --notes "Release v$VERSION
 
@@ -75,13 +101,11 @@ See [CHANGELOG](https://github.com/iterative-works/iw-cli/blob/main/CHANGELOG.md
 
 echo "  Created release: https://github.com/iterative-works/iw-cli/releases/tag/v$VERSION"
 
-# Step 4: Update 'latest' release
 echo ""
-echo "Step 4: Updating 'latest' release..."
+echo "Step 4: Updating 'vlatest' release..."
 LATEST_TARBALL="$RELEASE_DIR/iw-cli-latest.tar.gz"
 cp "$TARBALL" "$LATEST_TARBALL"
 
-# Check if vlatest exists, create or update
 if gh release view vlatest &> /dev/null; then
     gh release upload vlatest "$LATEST_TARBALL" "$BOOTSTRAP" --clobber
     gh release edit vlatest --notes "Latest stable release. Currently points to v$VERSION."
@@ -90,22 +114,10 @@ else
         --title "iw-cli latest" \
         --notes "Latest stable release. Currently points to v$VERSION."
 fi
-echo "  Updated 'latest' to point to v$VERSION"
-
-# Step 5: Commit version bump (only if VERSION actually changed)
-echo ""
-echo "Step 5: Committing version bump..."
-cd "$PROJECT_ROOT"
-if git diff --quiet "$VERSION_FILE"; then
-    echo "  VERSION already at $VERSION, no commit needed"
-else
-    git add "$VERSION_FILE"
-    git commit -m "chore: Bump version to $VERSION"
-    git push
-fi
+echo "  Updated 'vlatest' to point to v$VERSION"
 
 echo ""
-echo "=== Release v$VERSION complete! ==="
+echo "=== Release v$VERSION published ==="
 echo ""
 echo "  Versioned: https://github.com/iterative-works/iw-cli/releases/tag/v$VERSION"
 echo "  Latest:    https://github.com/iterative-works/iw-cli/releases/tag/vlatest"


### PR DESCRIPTION
## Why

`scripts/release.sh` failed in two coupled ways:

1. `gh release create v$VERSION` ran before the VERSION bump commit existed on `main`, so the tag pointed at whatever `origin/main` HEAD happened to be at that moment, not at the bump (this is exactly what happened with v0.6.2: tag at `8d19a44`, bump commit `9978d96` landed later via #386).
2. The trailing `git commit && git push` pushed the VERSION bump directly to `main`, which is rejected by branch protection.

## What

Split into two purpose-scoped scripts:

- **`scripts/release-prepare.sh <version>`** — from a clean `main`, creates `chore/bump-version-<version>`, bumps `VERSION`, pushes, opens the bump PR. Refuses dirty trees, non-`main` branches, existing same-version branches, same-version no-ops.
- **`scripts/release-publish.sh <version>`** — after the bump PR is merged, verifies `VERSION` on `main` matches the arg, captures `main` HEAD SHA, packages the tarball + `iw-bootstrap`, runs `gh release create v$VERSION --target $MAIN_SHA` so the tag pins to the bump commit, updates `vlatest`. Refuses if `v$VERSION` already exists.

Old `scripts/release.sh` deleted; `RELEASE.md` updated.

## Out of scope

`.github/workflows/release.yml` still fires on `v*` tag push and re-uploads the tarball — redundant with `release-publish.sh` now, but uploads are `--clobber`-safe so the overlap is wasteful, not broken.

## Test plan

- [ ] Dry-read both scripts; verify guards refuse dirty trees and non-`main` invocations
- [ ] Real-run `release-prepare.sh 0.6.3` once we have something to release; observe PR opened, no direct push to `main`
- [ ] After merging that PR, run `release-publish.sh 0.6.3`; observe `v0.6.3` tag at the bump commit, not earlier